### PR TITLE
Add Missing Cards, Set4 Cards, Ratings for bots, rarity, and set

### DIFF
--- a/FortybornJakeBotCardEvaluations.csv
+++ b/FortybornJakeBotCardEvaluations.csv
@@ -1,0 +1,817 @@
+Card Name,Set,"Rating 
+(A-F)","Rating
+(Draftmancer)",Source
+Agustin Madrigal,4,C,3,Fortyborn
+Cogsworth - Majordomo,4,B-,4,Fortyborn
+Daisy Duck - Lovely Lady,4,C,3,Fortyborn
+Daisy Duck - Musketeer Spy,4,C+,3,Fortyborn
+Donald Duck - Musketeer Soldier,4,C+,3,Fortyborn
+Félix Madrigal - Fun-Loving Family Man,4,C,3,Fortyborn
+Julieta Madrigal - Excellent Cook,4,B-,4,Fortyborn
+Max,4,C,3,Fortyborn
+Mickey Mouse - Leader of the Band,4,B-,4,Fortyborn
+Mirabel Madrigal - Prophecy Finder,4,C,3,Fortyborn
+Pluto - Rescue Dog,4,B-,4,Fortyborn
+Prince Eric - Seafaring Prince,4,C+,3,Fortyborn
+Prince Eric - Ursula's Groom,4,B-/C+,4,Fortyborn
+Stitch - Alien Dancer,4,C,3,Fortyborn
+Ursula - Vanessa,4,C,3,Fortyborn
+Bruno's Return,4,B-,4,Fortyborn
+First Aid,4,F,0,Fortyborn
+Lost in the Woods,4,C+,3,Fortyborn
+Sign The Scroll,4,F,0,Fortyborn
+Record Player,4,F,0,Fortyborn
+Atlantica,4,F,0,Fortyborn
+Antonio Madrigal,4,C,3,Fortyborn
+Belle - Untrained Mystic,4,C+,3,Fortyborn
+Camilo Madrigal - Prankster,4,B-,4,Fortyborn
+Dolores Madrigal - Easy Listener,4,B,4,Fortyborn
+"Flotsam - Ursula's ""Baby""",4,B,4,Fortyborn
+Flotsam & Jetsam - Entangling Eels,4,C,3,Fortyborn
+"Jetsam - Ursula's ""Baby""",4,C+,3,Fortyborn
+Luisa Madrigal - Magically Strong One,4,B,4,Fortyborn
+Magic Broom - Illuminary Keeper,4,C+,3,Fortyborn
+Magic Broom - Lively Sweeper,4,C-,2,Fortyborn
+Magical Maid,4,C,3,Fortyborn
+Marshmallow,4,D,1,Fortyborn
+Pico,4,C,3,Fortyborn
+Tick-Tock - Ever-Present Pursuer,4,C+,3,Fortyborn
+Ursula - Mad Sea Witch,4,C+,3,Fortyborn
+Poor Unfortunate Souls,4,D+,1,Fortyborn
+Swing Into Action,4,D-,1,Fortyborn
+Ursula's Plan,4,F,0,Fortyborn
+Rose Lantern,4,C+,3,Fortyborn
+Triton's Trident,4,F,0,Fortyborn
+Casa Madrigal,4,F,0,Fortyborn
+Diablo - Maleficent's Spy,4,D+,1,Fortyborn
+Gunther,4,B-/C+,4,Fortyborn
+Gus - Champion of Cheese,4,C,3,Fortyborn
+Heihei - Bumbling Rooster,4,C+,3,Fortyborn
+Jaq,4,B-,4,Fortyborn
+Megara - Captivating Cynic,4,D+,1,Fortyborn
+Megara - Liberated One,4,C,3,Fortyborn
+Pain,4,C,3,Fortyborn
+Panic,4,C-,2,Fortyborn
+Pegasus - Cloud Racer,4,B-,4,Fortyborn
+Pegasus - Gift for Hercules,4,C,3,Fortyborn
+Pete,4,C-,2,Fortyborn
+The Fates,4,C-,2,Fortyborn
+Tor,4,C+,3,Fortyborn
+Dodge,4,F,0,Fortyborn
+Make the Potion,4,B,4,Fortyborn
+Ursula's Trickery,4,C+,3,Fortyborn
+Hidden Inkcaster,4,C-,2,Fortyborn
+Signed Contract,4,D-/F,1,Fortyborn
+Vision Slab,4,D+,1,Fortyborn
+Hidden Cove,4,C-,2,Fortyborn
+Beast - Wounded,4,C-,2,Fortyborn
+Benja,4,C,3,Fortyborn
+Fa Zhou,4,D-,1,Fortyborn
+Hercules - Clumsy Kid,4,B-,4,Fortyborn
+Hercules - Daring Demigod,4,B,4,Fortyborn
+Khan,4,C,3,Fortyborn
+Li Shang - General's Son,4,C,3,Fortyborn
+Li Shang - Valorous General,4,C+,3,Fortyborn
+Mulan - Enemy of Entanglement,4,D+,1,Fortyborn
+Mulan - Injured Soldier,4,C-,2,Fortyborn
+Nessus,4,B-,4,Fortyborn
+Pegasus,4,B-,4,Fortyborn
+Raya - Guardian of the Dragon Gem,4,C-,2,Fortyborn
+Sisu - Daring Visitor,4,B-,4,Fortyborn
+Tong,4,C+,3,Fortyborn
+A Pirate's Life,4,D,1,Fortyborn
+Brawl,4,B,4,Fortyborn
+Medallion Weights,4,B,4,Fortyborn
+The Plank,4,B-,4,Fortyborn
+Vitalisphere,4,C-,2,Fortyborn
+Training Grounds,4,C+/B-,3,Fortyborn
+Anna - Braving the Storm,4,C+,3,Fortyborn
+Aurora - Tranquil Princess,4,C-,2,Fortyborn
+Fa Li,4,C,3,Fortyborn
+Flounder - Collector's Companion,4,C+/C,3,Fortyborn
+Hades - Meticulous Plotter,4,C+,3,Fortyborn
+Hans - Noble Scoundrel,4,C,3,Fortyborn
+Iduna,4,C+,3,Fortyborn
+Olaf - Carrot Enthusiast,4,C+,3,Fortyborn
+Olaf - Trusting Companion,4,C,3,Fortyborn
+Pascal,4,C,3,Fortyborn
+Scuttle,4,C-,2,Fortyborn
+Sisu,4,B-,4,Fortyborn
+Tuk Tuk,4,C,3,Fortyborn
+Transformed Chef,4,C+,3,Fortyborn
+Triton - Young Prince,4,B-/C+,4,Fortyborn
+Dig A Little Deeper,4,B+,4,Fortyborn
+Glean,4,D-,1,Fortyborn
+Seldom All They Seem,4,D+,1,Fortyborn
+Great Stone Dragon,4,C,3,Fortyborn
+Ice Block,4,C+,3,Fortyborn
+Winter Camp,4,D,1,Fortyborn
+Aladdin - Brave Rescuer,4,C-,2,Fortyborn
+Aladdin - Resolute Swordsman,4,C,3,Fortyborn
+Arges,4,C,3,Fortyborn
+Ariel - Determined Mermaid,4,C,3,Fortyborn
+Beast - Thick-Skinned,4,C,3,Fortyborn
+Chi-Fu,4,D+,1,Fortyborn
+Chien-Po,4,B-,4,Fortyborn
+Li Shang,4,C+,3,Fortyborn
+Ling,4,C,3,Fortyborn
+Luisa Madrigal - Rock of the Family,4,C+,3,Fortyborn
+Magic Broom - Aerial Cleaner,4,C+,3,Fortyborn
+Mickey Mouse - Standard Bearer,4,C+,3,Fortyborn
+Mulan - Armored Fighter,4,C,3,Fortyborn
+Yao,4,C+,3,Fortyborn
+Avalanche,4,B,4,Fortyborn
+"I Find 'Em, I Flatten 'Em",4,D-,1,Fortyborn
+The Mob Song,4,C,3,Fortyborn
+Triton's Decree,4,C-,2,Fortyborn
+Fortisphere,4,C+,3,Fortyborn
+Imperial Bow,4,D,1,Fortyborn
+Thebes - The Big Olive,4,D,1,Fortyborn
+Alma Madrigal,4,C-,2,Fortyborn
+Ariel - Singing Mermaid,4,C+,3,Fortyborn
+Golden Harp,4,F,0,Fortyborn
+Goofy - Musketeer Swordsman,4,C+,3,Fortyborn
+Ursula - Eric's Bride,4,C+,3,Fortyborn
+Look At This Family,4,B,4,Fortyborn
+Miracle Candle,4,D,1,Fortyborn
+The Underworld,4,C-,2,Fortyborn
+Bruno Madrigal - Out of the Shadows,4,B-,4,Fortyborn
+Elsa - Storm Chaser,4,B/B-,4,Fortyborn
+Isabela Madrigal,4,B,4,Fortyborn
+Mrs. Potts,4,C+,3,Fortyborn
+Pepa Madrigal,4,C,3,Fortyborn
+Second Star To The Right,4,D,1,Fortyborn
+Mystical Rose,4,F,0,Fortyborn
+Ursula's Lair,4,B-,4,Fortyborn
+Cri-Kee,4,B+,4,Fortyborn
+Hera,4,C+,3,Fortyborn
+Jasmine - Desert Warrior,4,B,4,Fortyborn
+Prince Phillip,4,C+,3,Fortyborn
+The Muses,4,D,1,Fortyborn
+Under The Sea,4,B,4,Fortyborn
+We Don't Talk About Bruno,4,B+,4,Fortyborn
+Ursula's Garden,4,D-,1,Fortyborn
+Goofy - Super Goof,4,B-,4,Fortyborn
+Lumiere - Fiery Friend,4,B-,4,Fortyborn
+Namaari - Heir of Fang,4,A,5,Fortyborn
+Sisu - Emboldened Warrior,4,B-,4,Fortyborn
+Tuk Tuk - Lively Partner,4,B-,4,Fortyborn
+Be King Undisputed,4,B-,4,Fortyborn
+Imperial Proclamation,4,C+,3,Fortyborn
+Snuggly Duckling,4,D-,1,Fortyborn
+Dang Hu,4,C+,3,Fortyborn
+John Silver - Terror of the Realm,4,B-/C+,4,Fortyborn
+Prince Phillip - Gallant Defender,4,B,4,Fortyborn
+Rapunzel - Appreciative Artist,4,C+,3,Fortyborn
+Triton - Discerning King,4,D,1,Fortyborn
+Treasures Untold,4,F,0,Fortyborn
+Field of Ice,4,D-,1,Fortyborn
+Ariel's Grotto,4,F,0,Fortyborn
+Hercules - Beloved Hero,4,B+,4,Fortyborn
+Lefou,4,C+,3,Fortyborn
+Mickey Mouse - Playful Sorcerer,4,C+,3,Fortyborn
+Philoctetes,4,B+,4,Fortyborn
+Rajah,4,C+,3,Fortyborn
+One Last Hope,4,C,3,Fortyborn
+RLS Legacy's Cannon,4,F,0,Fortyborn
+The Wall,4,F,0,Fortyborn
+Cinderella - Melody Weaver,4,D+,1,Fortyborn
+Gaston - Despicable Dealer,4,B-,4,Fortyborn
+Mickey Mouse - Musketeer Captain,4,B-,4,Fortyborn
+Minnie Mouse - Musketeer Champion,4,B-,4,Fortyborn
+Mirabel Madrigal - Gift of the Family,4,B-/C+,4,Fortyborn
+Belle - Accomplished Mystic,4,B+,4,Fortyborn
+Bruno Madrigal - Undetected Uncle,4,B-,4,Fortyborn
+Peter Pan - Shadow Finder,4,B/B+,4,Fortyborn
+Ursula - Sea Witch Queen,4,B,4,Fortyborn
+Yen Sid - Powerful Sorcerer,4,D+,1,Fortyborn
+Diablo - Devoted Herald,4,A,5,Fortyborn
+Hades - Double Dealer,4,D,1,Fortyborn
+Pete - Born to Cheat,4,C+,3,Fortyborn
+Prince Phillip - Vanquisher of Foes,4,D,1,Fortyborn
+Zeus - Mr. Lightning Bolts,4,B,4,Fortyborn
+Flynn Rider - Frenemy,4,C+,3,Fortyborn
+Mulan - Elite Archer,4,A+,5,Fortyborn
+Noi - Acrobatic Baby,4,B-,4,Fortyborn
+Raya - Fierce Protector,4,C+/C,3,Fortyborn
+Sisu - Empowered Sibling,4,B,4,Fortyborn
+Anna - True-Hearted,4,C,3,Fortyborn
+Ariel - Treasure Collector,4,C+,3,Fortyborn
+Aurora - Lore Guardian,4,C,3,Fortyborn
+The Queen - Diviner,4,C,3,Fortyborn
+Triton - Champion of Atlantica,4,D,1,Fortyborn
+Ariel - Sonic Warrior,4,B+,4,Fortyborn
+Donald Duck - Buccaneer,4,C+,3,Fortyborn
+Magic Broom - Brigade Commander,4,D+,1,Fortyborn
+Piglet - Sturdy Swordsman,4,B-,4,Fortyborn
+Raya - Unstoppable Force,4,A,5,Fortyborn
+Joshua Sweet,3,B-,4,Fortyborn
+Kida - Atlantean,3,C,3,Fortyborn
+Miss Bianca,3,D,1,Fortyborn
+Mr. Snoops,3,C+/B-,3,Fortyborn
+Nani,3,B,4,Fortyborn
+Orville,3,C,3,Fortyborn
+Patch,3,C+,3,Fortyborn
+Pluto - Friendly Pooch,3,D,1,Fortyborn
+Queen of Hearts - Wonderland Empress,3,C-,2,Fortyborn
+Rolly,3,C+,3,Fortyborn
+Tinker Bell - Generous Fairy,3,C+,3,Fortyborn
+Wendy Darling - Talented Sailor,3,C,3,Fortyborn
+Has Set My Heaaaaaaart . . .,3,D,1,Fortyborn
+99 Puppies,3,F,0,Fortyborn
+Boss's Orders,3,D-,1,Fortyborn
+Heal What Has Been Hurt,3,C+,3,Fortyborn
+Quick Patch,3,F,0,Fortyborn
+Cleansing Rainwater,3,D+,1,Fortyborn
+Wildcat's Wrench,3,D+,1,Fortyborn
+Never Land,3,C,3,Fortyborn
+Tiana's Palace,3,C+,3,Fortyborn
+Chernabog's Followers - Creatures of Evil,3,C+,3,Fortyborn
+Diablo,3,C-,2,Fortyborn
+De Vil Manor,3,C,3,Fortyborn
+Kuzco's Palace - Home of the Emperor,3,C-,2,Fortyborn
+Hydros,3,C+,3,Fortyborn
+Iago,3,B-,4,Fortyborn
+Jafar - Lamp Thief,3,B-,4,Fortyborn
+Lena Sabrewing,3,D+,1,Fortyborn
+Magic Broom - Dancing Duster,3,F,0,Fortyborn
+Magic Broom - Swift Cleaner,3,B-,4,Fortyborn
+Magic Broom - The Big Sweeper,3,D,1,Fortyborn
+Magic Carpet,3,B-,4,Fortyborn
+Magica De Spell - Ambitious Witch,3,C,3,Fortyborn
+Magica De Spell - Thieving Sorceress,3,C+,3,Fortyborn
+Mama Odie - Voice of Wisdom,3,C+/B-,3,Fortyborn
+Pua,3,C,3,Fortyborn
+The Firebird,3,C+,3,Fortyborn
+The Queen,3,C,3,Fortyborn
+Bestow a Gift,3,C-,2,Fortyborn
+It Calls Me,3,C-,2,Fortyborn
+Last-Ditch Effort,3,D,1,Fortyborn
+The Boss Is on a Roll,3,C,3,Fortyborn
+The Sorcerer's Tower,3,C,3,Fortyborn
+Cubby,3,C+,3,Fortyborn
+Don Karnage,3,B,4,Fortyborn
+Flotsam,3,C+,3,Fortyborn
+Friar Tuck,3,C+,3,Fortyborn
+Jetsam,3,C-,2,Fortyborn
+Kit Cloudkicker,3,B-/C+,4,Fortyborn
+Milo Thatch - Clever Cartographer,3,C,3,Fortyborn
+Prince John - Phony King,3,D+,1,Fortyborn
+Sir Hiss,3,B-,4,Fortyborn
+Skippy,3,D,1,Fortyborn
+Starkey,3,C,3,Fortyborn
+Ursula - Deceiver,3,D+,1,Fortyborn
+Wildcat,3,B-,4,Fortyborn
+Zazu,3,C-,2,Fortyborn
+Forbidden Mountain - Maleficent's Castle,3,C,3,Fortyborn
+Touched My Heart,3,D-,1,Fortyborn
+I Will Find My Way,3,C,3,Fortyborn
+Strike a Good Match,3,B-,4,Fortyborn
+Airfoil,3,F,0,Fortyborn
+Robin's Bow,3,D,1,Fortyborn
+Billy Bones,3,B-,4,Fortyborn
+Della Duck,3,C+,3,Fortyborn
+HeiHei - Accidental Explorer,3,C,3,Fortyborn
+Jim Hawkins - Thrill Seeker,3,C,3,Fortyborn
+Kakamora,3,D,1,Fortyborn
+Maui - Soaring Demigod,3,C,3,Fortyborn
+Milo Thatch - Spirited Scholar,3,D+,1,Fortyborn
+Moana - Undeterred Voyager,3,B-,4,Fortyborn
+Nutsy,3,C,3,Fortyborn
+Peter Pan - Never Land Hero,3,C-,2,Fortyborn
+Scroop,3,D+,1,Fortyborn
+Slightly,3,B-,4,Fortyborn
+Stitch - Little Rocket,3,B-,4,Fortyborn
+Trigger,3,C-,2,Fortyborn
+Webby Vanderquack,3,C,3,Fortyborn
+Divebomb,3,F,0,Fortyborn
+I've Got a Dream,3,D,1,Fortyborn
+Voyage,3,C,3,Fortyborn
+Sumerian Talisman,3,B+,4,Fortyborn
+Agrabah,3,C,3,Fortyborn
+Jolly Roger,3,B-,4,Fortyborn
+Captain Amelia,3,C,3,Fortyborn
+Dewey,3,C+,3,Fortyborn
+Flintheart Glomgold,3,C+,3,Fortyborn
+Genie - Cramped in the Lamp,3,C,3,Fortyborn
+Gramma Tala - Keeper of Ancient Stories,3,B,4,Fortyborn
+King Louie - Bandleader,3,C+,3,Fortyborn
+Kit Cloudkicker - Navigator,3,C,3,Fortyborn
+Kit Cloudkicker - Spunky Bear Cub,3,F,0,Fortyborn
+Louie,3,B-,4,Fortyborn
+Maid Marian,3,B-,4,Fortyborn
+Pluto - Mickey's Clever Friend,3,C,3,Fortyborn
+Rufus,3,C,3,Fortyborn
+Scrooge McDuck - Uncle Moneybags,3,D+,1,Fortyborn
+The Queen - Mirror Seeker,3,C,3,Fortyborn
+Distract,3,C+,3,Fortyborn
+How Far I'll Go,3,B,4,Fortyborn
+Repair,3,D,1,Fortyborn
+Scrooge's Top Hat,3,F,0,Fortyborn
+Vault Door,3,F,0,Fortyborn
+McDuck Manor,3,C,3,Fortyborn
+Motunui,3,B-,4,Fortyborn
+Chief Tui - Proud of Motunui,3,C,3,Fortyborn
+Eeyore,3,C+,3,Fortyborn
+Helga Sinclair - Right-Hand Woman,3,C+,3,Fortyborn
+Kida - Royal Warrior,3,B-,4,Fortyborn
+Little John - Robin's Pal,3,B-,4,Fortyborn
+Lythos,3,B-,4,Fortyborn
+Mickey Mouse - Stalwart Explorer,3,C-,2,Fortyborn
+Minnie Mouse - Funky Spelunker,3,F,0,Fortyborn
+Mr. Smee,3,C+,3,Fortyborn
+Nala - Fierce Friend,3,C,3,Fortyborn
+Razoul,3,C+,3,Fortyborn
+Robin Hood - Beloved Outlaw,3,C,3,Fortyborn
+Simba - Rightful King,3,B-,4,Fortyborn
+Thaddeus E. Klang,3,D+,1,Fortyborn
+Ba-Boom!,3,B-,4,Fortyborn
+Olympus Would Be That Way,3,D-,1,Fortyborn
+Rise of the Titans,3,C+,3,Fortyborn
+Captain Hook's Rapier,3,C+,3,Fortyborn
+Gizmosuit,3,D+,1,Fortyborn
+Nottingham,3,C,3,Fortyborn
+The Bayou,3,C,3,Fortyborn
+Baloo - von Bruinwald XIII,3,D,1,Fortyborn
+Bernard - Brand-New Agent,3,B-,4,Fortyborn
+Lucky - The 15th Puppy,3,B-,4,Fortyborn
+Minnie Mouse - Musical Artist,3,C,3,Fortyborn
+Pluto - Determined Defender,3,B,4,Fortyborn
+The Bare Necessities,3,D+,1,Fortyborn
+Heart of Atlantis,3,F,0,Fortyborn
+Pride Lands,3,C+,3,Fortyborn
+Rafiki - Mystical Fighter,3,C+,3,Fortyborn
+Stratos - Tornado Titan,3,B,4,Fortyborn
+Treasure Guardian - Protector of the Cave,3,F,0,Fortyborn
+Ursula - Sea Witch,3,B-,4,Fortyborn
+The Boss Is on a Roll,3,B,4,Fortyborn
+The Lamp,3,F,0,Fortyborn
+The Sorcerer's Hat,3,F,0,Fortyborn
+The Queen's Castle,3,B,4,Fortyborn
+Cursed Merfolk - Ursula's Handiwork,3,C+,3,Fortyborn
+Helga Sinclair - Vengeful Partner,3,C+,3,Fortyborn
+Morph - Space Goo,3,C,3,Fortyborn
+Peter Pan - Lost Boy Leader,3,D,1,Fortyborn
+Robin Hood - Daydreamer,3,B,4,Fortyborn
+Stitch - Covert Agent,3,B-,4,Fortyborn
+Starlight Vial,3,F,0,Fortyborn
+Fang - River City,3,B-,4,Fortyborn
+Captain Hook - Master Swordsman,3,B-,4,Fortyborn
+Maui - Whale,3,B-,4,Fortyborn
+Moana - Born Leader,3,D+,1,Fortyborn
+Peter Pan - Pirate's Bane,3,B,4,Fortyborn
+Simba - Scrappy Cub,3,C-,2,Fortyborn
+On Your Feet! Now!,3,D,1,Fortyborn
+Maui's Fish Hook,3,C+,3,Fortyborn
+RLS Legacy,3,C+,3,Fortyborn
+Audrey Ramirez - The Engineer,3,D+,1,Fortyborn
+Gyro Gearloose - Gadget Whiz,3,D-,1,Fortyborn
+Huey - Savvy Nephew,3,C+,3,Fortyborn
+Mama Odie,3,C-,2,Fortyborn
+Friend Like Me,3,F,0,Fortyborn
+Aurelian Gyrosensor,3,B-,4,Fortyborn
+Heart of Te Fiti,3,F,0,Fortyborn
+Belle's House - Maurice's Workshop,3,F,0,Fortyborn
+Gustav the Giant - Terror of the Kingdom,3,C+,3,Fortyborn
+Hades - Hotheaded Ruler,3,C,3,Fortyborn
+John Silver - Greedy Treasure Seeker,3,C-,2,Fortyborn
+Mufasa - Champion of the Pride Lands,3,C+,3,Fortyborn
+Pyros - Lava Titan,3,B,4,Fortyborn
+And Then Along Came Zeus,3,B+,4,Fortyborn
+Map of Treasure Planet,3,F,0,Fortyborn
+Maui's Place of Exile,3,B-,4,Fortyborn
+Chernabog - Evildoer,3,B-,4,Fortyborn
+Piglet - Pooh Pirate Captain,3,B-,4,Fortyborn
+Pongo - Determined Father,3,B+/A-,4,Fortyborn
+Alice - Tea Alchemist,3,C,3,Fortyborn
+Genie - Supportive Friend,3,B+,4,Fortyborn
+Magica De Spell - The Midas Touch,3,F,0,Fortyborn
+Helga Sinclair - Femme Fatale,3,B+/A-,4,Fortyborn
+Lyle Tiberius Rourke - Cunning Mercenary,3,B,4,Fortyborn
+Shenzi - Hyena Pack Leader,3,F,0,Fortyborn
+Ariel - Adventurous Collector,3,B,4,Fortyborn
+Madame Medusa - The Boss,3,A-,5,Fortyborn
+Prince Eric - Expert Helmsman,3,A,5,Fortyborn
+Scrooge McDuck - Richest Duck in the World,3,C-,2,Fortyborn
+Tinker Bell - Very Clever Fairy,3,D+,1,Fortyborn
+Wendy Darling - Authority on Peter Pan,3,C-,2,Fortyborn
+Little John - Resourceful Outlaw,3,D,1,Fortyborn
+Sheriff of Nottingham - Corrupt Official,3,D-,1,Fortyborn
+Simba - Fighting Prince,3,A,5,Fortyborn
+Kida - Protector of Atlantis,3,B+,4,Fortyborn
+Perdita - Devoted Mother,3,B+,4,Fortyborn
+Jafar - Striking Illusionist,3,C+,3,Fortyborn
+Maleficent - Mistress of All Evil,3,A-,5,Fortyborn
+Milo Thatch - King of Atlantis,3,A-,5,Fortyborn
+Ursula - Deceiver of All,3,C,3,Fortyborn
+Hydra - Deadly Serpent,3,A,5,Fortyborn
+Jim Hawkins - Space Traveler,3,C,3,Fortyborn
+Gramma Tala - Spirit of the Ocean,3,D+,1,Fortyborn
+Lucky Dime,3,F,0,Fortyborn
+Mickey Mouse - Trumpeter,3,F,0,Fortyborn
+Robin Hood - Champion of Sherwood,3,A,5,Fortyborn
+Dalmatian Puppy - Tail Wagger,3,C,3,Fortyborn
+Archimedes,1,C,3,Fortyborn
+Befuddle,1,D-,1,Fortyborn
+Captain Hook,1,C+,3,Fortyborn
+Control Your Temper,1,D,1,Fortyborn
+Develop Your Brain,1,B-,4,Fortyborn
+Dinglehopper,1,D+,1,Fortyborn
+Fan The Flames,1,F,0,Fortyborn
+Fire the Cannons,1,B,4,Fortyborn
+He's Got a Sword,1,D-,1,Fortyborn
+Healing Glow,1,D-,1,Fortyborn
+HeiHei - Boat Snack,1,D+,1,Fortyborn
+Lilo,1,C+,3,Fortyborn
+Magic Golden Flower,1,D-,1,Fortyborn
+Olaf - Friendly Snowman,1,D+,1,Fortyborn
+Minnie Mouse,1,D+,1,Fortyborn
+Pascal,1,C,3,Fortyborn
+Reflection,1,F,0,Fortyborn
+Scepter Of Arendelle,1,C-,2,Fortyborn
+Shield of Virtue,1,D,1,Fortyborn
+Simba,1,C-,2,Fortyborn
+Stampede,1,D-,1,Fortyborn
+Timon,1,D-,1,Fortyborn
+Vicious Betrayal,1,D-,1,Fortyborn
+Work Together,1,F,0,Fortyborn
+Aladdin - Cornered Swordsman,1,C-,2,Fortyborn
+Aladdin - Prince Ali,1,D+,1,Fortyborn
+Aurora,1,C+,3,Fortyborn
+Be Our Guest,1,C+/B-,3,Fortyborn
+Beast's Mirror,1,B/B-,4,Fortyborn
+Break,1,F,0,Fortyborn
+Coconut Basket,1,C+,3,Fortyborn
+Cruella De Vil - Miserable As Usual,1,B-,4,Fortyborn
+Cut to the Chase,1,F/D-,0,Fortyborn
+Donald Duck,1,C,3,Fortyborn
+Dr. Facilier,1,D,1,Fortyborn
+Duke Of Weselton - Opportunistic Official,1,C,3,Fortyborn
+Goons - Maleficent's Underlings,1,C,3,Fortyborn
+Dr. Facilier's Cards,1,F,0,Fortyborn
+Flynn Rider,1,B,4,Fortyborn
+Freeze,1,F,0,Fortyborn
+Frying Pan,1,F,0,Fortyborn
+Gaston,1,C-,2,Fortyborn
+Gramma Tala,1,D,1,Fortyborn
+Lantern,1,D+,1,Fortyborn
+Lefou - Bumbler,1,C-,2,Fortyborn
+Lefou - Instigator,1,C,3,Fortyborn
+Magic Broom,1,D,1,Fortyborn
+Magic Mirror,1,B-,4,Fortyborn
+Megara,1,D+,1,Fortyborn
+One Jump Ahead,1,D,1,Fortyborn
+Philoctetes,1,B-,4,Fortyborn
+Prince Eric,1,C+,3,Fortyborn
+Ransack,1,D-,1,Fortyborn
+Sebastian,1,D,1,Fortyborn
+Simba,1,B,4,Fortyborn
+Stolen Scimitar,1,D-,1,Fortyborn
+Sudden Chill,1,F,0,Fortyborn
+Tamatoa,1,C-,2,Fortyborn
+Tangle,1,F,0,Fortyborn
+Ursula's Cauldron,1,C-/D+,2,Fortyborn
+Yzma,1,C,3,Fortyborn
+Abu,1,C-,2,Fortyborn
+Horace,1,C-,2,Fortyborn
+Jasmine,1,C,3,Fortyborn
+Lilo,1,C,3,Fortyborn
+Mickey Mouse - Steamboat Pilot,1,C,3,Fortyborn
+Mr. Smee,1,C,3,Fortyborn
+Aladdin,1,D-/F,1,Fortyborn
+Ariel,1,D,1,Fortyborn
+Belle,1,C-,2,Fortyborn
+Cheshire Cat,1,C+,3,Fortyborn
+Do It Again,1,F,0,Fortyborn
+Dr. Facilier,1,C-,2,Fortyborn
+Elsa,1,B-,4,Fortyborn
+Fishbone Quill,1,F,0,Fortyborn
+Friends On The Other Side,1,B+,4,Fortyborn
+Hercules,1,C+,3,Fortyborn
+Iago,1,D,1,Fortyborn
+If It's Not Baroque,1,F,0,Fortyborn
+Jasper,1,C-,2,Fortyborn
+Just in Time,1,F,0,Fortyborn
+Maleficent,1,B-,4,Fortyborn
+Maximus,1,C+/B-,3,Fortyborn
+Mickey Mouse - Detective,1,D+,1,Fortyborn
+Mother Knows Best,1,B-,4,Fortyborn
+Part of Your World,1,C-,2,Fortyborn
+Peter Pan - Fearless Fighter,1,C-,2,Fortyborn
+Peter Pan - Never Landing,1,B-,4,Fortyborn
+Plasma Blaster,1,D,1,Fortyborn
+Poisoned Apple,1,D-/F,1,Fortyborn
+Rafiki,1,C+/B-,3,Fortyborn
+Smash,1,B-,4,Fortyborn
+The Beast is Mine,1,F,0,Fortyborn
+Tinker Bell,1,B-,4,Fortyborn
+Ursula's Shell Necklace,1,F,0,Fortyborn
+White Rabbit's Pocket Watch,1,C+,3,Fortyborn
+Elsa - Queen Regent,1,C,3,Fortyborn
+Hans - Scheming Prince,1,C+/B-,3,Fortyborn
+Maleficent,1,C,3,Fortyborn
+Pumbaa,1,C,3,Fortyborn
+Scar,1,C-,2,Fortyborn
+Anna,1,D+,1,Fortyborn
+Ariel - On Human Legs,1,C,3,Fortyborn
+Ariel - Whoseit Collector,1,D-,1,Fortyborn
+Aurora,1,B-,4,Fortyborn
+Belle,1,D+,1,Fortyborn
+Captain Hook,1,C-/D+,2,Fortyborn
+Cinderella,1,C+,3,Fortyborn
+Donald Duck,1,B-,4,Fortyborn
+Elsa - Ice Surfer,1,D+,1,Fortyborn
+Eye of the Fates,1,F,0,Fortyborn
+Hades,1,B,4,Fortyborn
+Hakuna Matata,1,D-,1,Fortyborn
+Hans - Thirteenth in Line,1,B-/B,4,Fortyborn
+Jafar - Keeper of Secrets,1,D+,1,Fortyborn
+Jafar - Wicked Sorcerer,1,C+,3,Fortyborn
+Jetsam,1,B-,4,Fortyborn
+Merlin,1,B-,4,Fortyborn
+Mickey Mouse,1,C,3,Fortyborn
+Musketeer Tabard,1,F,0,Fortyborn
+Kristoff - Official Ice Master,1,C,3,Fortyborn
+Pongo,1,B,4,Fortyborn
+Prince Phillip,1,C+,3,Fortyborn
+Rapunzel,1,A+,5,Fortyborn
+Sword of Truth,1,F,0,Fortyborn
+Tinker Bell,1,B+,4,Fortyborn
+You Have Forgotten Me,1,C+,3,Fortyborn
+Zeus,1,C+,3,Fortyborn
+Captain,1,C+,3,Fortyborn
+Cerberus,1,C+/B-,3,Fortyborn
+Jumba Jookiba,1,C+,3,Fortyborn
+Maleficent,1,B-,4,Fortyborn
+A Whole New World,1,D+,1,Fortyborn
+Aurora,1,B-,4,Fortyborn
+Beast - Hardheaded,1,C+,3,Fortyborn
+Beast - Wolfsbane,1,B-,4,Fortyborn
+Captain Hook,1,C+,3,Fortyborn
+Donald Duck,1,D+,1,Fortyborn
+Dragon Fire,1,B+,4,Fortyborn
+Flotsam,1,C,3,Fortyborn
+Goofy - Daredevil,1,B,4,Fortyborn
+Goofy - Musketeer,1,B-,4,Fortyborn
+Grab Your Sword,1,A+,5,Fortyborn
+Jasmine,1,B,4,Fortyborn
+Kuzco,1,A-,5,Fortyborn
+Let It Go,1,B+,4,Fortyborn
+Mad Hatter,1,B,4,Fortyborn
+Maui,1,B+,4,Fortyborn
+Maximus,1,B+,4,Fortyborn
+Moana - Chosen by the Ocean,1,C-,2,Fortyborn
+Moana - Of Motunui,1,C,3,Fortyborn
+Mulan,1,B,4,Fortyborn
+Simba,1,C,3,Fortyborn
+Starkey,1,D+,1,Fortyborn
+Steal from the Rich,1,F,0,Fortyborn
+The Queen,1,A-/B+,4,Fortyborn
+Tinker Bell,1,B-,4,Fortyborn
+Kronk,1,B-,4,Fortyborn
+Mufasa,1,B-,4,Fortyborn
+Sven,1,C+,3,Fortyborn
+Genie,1,A-,5,Fortyborn
+John Silver,1,B+,4,Fortyborn
+Lady Tremaine,1,D-,1,Fortyborn
+Marshmallow,1,B+,4,Fortyborn
+Maurice,1,C,3,Fortyborn
+Mickey Mouse,1,B-,4,Fortyborn
+Mother Gothel,1,B,4,Fortyborn
+Rapunzel,1,D+,1,Fortyborn
+Robin Hood,1,B,4,Fortyborn
+Sergeant Tibbs - Courageous Cat,1,C,3,Fortyborn
+Scar,1,B+,4,Fortyborn
+Stitch - New Dog,1,C,3,Fortyborn
+Stitch - Rock Star,1,A+,5,Fortyborn
+Te Ka - Heartless,1,B,4,Fortyborn
+Te Ka - The Burning One,1,C+,3,Fortyborn
+The Wardrobe - Belle's Confidant,1,C,3,Fortyborn
+Tigger,1,B,4,Fortyborn
+Tinkerbell,1,A+,5,Fortyborn
+Triton,1,C+,3,Fortyborn
+Maui,1,C,3,Fortyborn
+Aladdin,1,B,4,Fortyborn
+Be Prepared,1,B+,4,Fortyborn
+Captain Hook,1,C+,3,Fortyborn
+Chief Tui,1,B-,4,Fortyborn
+Dr. Facilier,1,A-,5,Fortyborn
+Elsa,1,B,4,Fortyborn
+Gantu,1,D+,1,Fortyborn
+Genie,1,C,3,Fortyborn
+Hades - King of Olympus,1,D,1,Fortyborn
+Hades - Infernal Schemer,1,A-,5,Fortyborn
+Maleficent,1,A,5,Fortyborn
+Mickey Mouse - Brave Little Tailor,1,B-,4,Fortyborn
+Mickey Mouse - Artful Rogue,1,D+,1,Fortyborn
+Scar,1,D+,1,Fortyborn
+Simba,1,B-,4,Fortyborn
+Stitch - Abomination,1,B-,4,Fortyborn
+Stitch - Carefree Surfer,1,A-,5,Fortyborn
+Flounder - Voice of Reason,1,C,3,Fortyborn
+Tamatoa,1,D+,1,Fortyborn
+Ursula,1,B,4,Fortyborn
+Fairy Godmother - Mystic Armorer,2,A,5,Frank Karsten
+Cogsworth - Grandfather Clock,2,A,5,Frank Karsten
+Beast - Tragic Hero,2,A,5,Frank Karsten
+Beast - Relentless,2,A,5,Frank Karsten
+The Queen - Commanding Presence,2,A,5,Frank Karsten
+Kronk - Junior Chipmunk,2,A,5,Frank Karsten
+Yzma - Scary Beyond All Reason,2,A,5,Frank Karsten
+Snow White - Well Wisher,2,A,5,Frank Karsten
+Lady Tremaine - Imperious Queen,2,A,5,Frank Karsten
+Beast - Selfless Protector,2,A,5,Frank Karsten
+Queen of Hearts - Sensing Weakness,2,B+,4,Frank Karsten
+Gaston - Intellectual Powerhouse,2,B+,4,Frank Karsten
+Alice - Growing Girl,2,B+,4,Frank Karsten
+Sisu - Divine Water Dragon,2,B+,4,Frank Karsten
+Belle - Hidden Archer,2,B+,4,Frank Karsten
+Hercules - Divine Hero,2,B+,4,Frank Karsten
+Mufasa - Betrayed Leader,2,B+,4,Frank Karsten
+Merlin - Rabbit,2,B+,4,Frank Karsten
+Pacha - Village Leader,2,B+,4,Frank Karsten
+Little John - Loyal Friend,2,B+,4,Frank Karsten
+Jafar - Dreadnought,2,B+,4,Frank Karsten
+Strength of a Raging Fire,2,B+,4,Frank Karsten
+World's Greatest Criminal Mind,2,B+,4,Frank Karsten
+Let the Storm Rage On,2,B+,4,Frank Karsten
+Cinderella - Stouthearted,2,B+,4,Frank Karsten
+Merlin - Crab,2,B+,4,Frank Karsten
+Minnie Mouse - Stylish Surfer,2,B+,4,Frank Karsten
+Lucifer - Cunning Cat,2,B+,4,Frank Karsten
+Madam Mim - Fox,2,B+,4,Frank Karsten
+Shere Khan - Menacing Predator,2,B+,4,Frank Karsten
+Dr. Facilier - Fortune Teller,2,B+,4,Frank Karsten
+HeiHei - Persistent Presence,2,B+,4,Frank Karsten
+Peter Pan's Shadow - Not Sewn On,2,B+,4,Frank Karsten
+Ray - Easygoing Firefly,2,B+,4,Frank Karsten
+Scar - Vicious Cheater,2,B,4,Frank Karsten
+Namaari - Nemesis,2,B,4,Frank Karsten
+Rabbit - Reluctant Host,2,B,4,Frank Karsten
+Flynn Rider - His Own Biggest Fan,2,B,4,Frank Karsten
+Cobra Bubbles - Just a Social Worker,2,B,4,Frank Karsten
+Madam Mim - Purple Dragon,2,B,4,Frank Karsten
+Daisy Duck - Secret Agent,2,B,4,Frank Karsten
+Winnie The Pooh - Hunny Wizard,2,B,4,Frank Karsten
+Virana - Fang Chief,2,B,4,Frank Karsten
+Card Soldiers - Full Deck,2,B,4,Frank Karsten
+Happy - Good-Natured,2,B,4,Frank Karsten
+Fairy Godmother - Pure Heart,2,B,4,Frank Karsten
+Li Shang - Archery Instructor,2,B,4,Frank Karsten
+Fairy Godmother - Here to Help,2,B,4,Frank Karsten
+Yzma - Without Beauty Sleep,2,B,4,Frank Karsten
+Donald Duck - Not Again!,2,B,4,Frank Karsten
+Queen of Hearts - Capricious Monarch,2,B,4,Frank Karsten
+Donald Duck - Deep-Sea Diver,2,B,4,Frank Karsten
+Ratigan - Criminal Mastermind,2,B,4,Frank Karsten
+Sleepy - Nodding Off,2,B,4,Frank Karsten
+King Louie - Jungle VIP,2,B,4,Frank Karsten
+Madam Mim - Snake,2,B,4,Frank Karsten
+The Prince - Never Gives Up,2,B,4,Frank Karsten
+Hypnotize,2,B,4,Frank Karsten
+Mulan - Soldier in Training,2,B-,4,Frank Karsten
+Tuk Tuk - Wrecking Ball,2,B-,4,Frank Karsten
+Lumiere - Hotheaded Candelabra,2,B-,4,Frank Karsten
+Pawpsicle,2,B-,4,Frank Karsten
+Snow White - Lost in the Forest,2,B-,4,Frank Karsten
+Ring The Bell,2,B-,4,Frank Karsten
+Painting the Roses Red,2,B-,4,Frank Karsten
+Fidget - Ratigan's Henchman,2,B-,4,Frank Karsten
+Improvise,2,B-,4,Frank Karsten
+The Queen - Regal Monarch,2,B-,4,Frank Karsten
+Charge!,2,B-,4,Frank Karsten
+Chip the Teacup - Gentle Soul,2,B-,4,Frank Karsten
+Owl - Logical Lecturer,2,B-,4,Frank Karsten
+Cruella De Vil - Perfectly Wretched,2,B-,4,Frank Karsten
+Lawrence - Jealous Manservant,2,B-,4,Frank Karsten
+Grand Pabbie - Oldest and Wisest,2,B-,4,Frank Karsten
+Cheshire Cat - From the Shadows,2,B-,4,Frank Karsten
+Raya - Leader of Heart,2,B-,4,Frank Karsten
+Beast - Forbidding Recluse,2,C+,3,Frank Karsten
+Grumpy - Bad-Tempered,2,C+,3,Frank Karsten
+Felicia - Always Hungry,2,C+,3,Frank Karsten
+Elsa - Gloves Off,2,C+,3,Frank Karsten
+Cogsworth - Talking Clock,2,C+,3,Frank Karsten
+Donald Duck - Perfect Gentleman,2,C+,3,Frank Karsten
+Hercules - Hero in Training,2,C+,3,Frank Karsten
+Boun - Precocious Entrepreneur,2,C+,3,Frank Karsten
+Pinocchio - On the Run,2,C+,3,Frank Karsten
+Rapunzel - Sunshine,2,C+,3,Frank Karsten
+Basil - Great Mouse Detective,2,C+,3,Frank Karsten
+Cruella De Vil - Fashionable Cruiser,2,C+,3,Frank Karsten
+Christopher Robin - Adventurer,2,C+,3,Frank Karsten
+Jafar - Royal Vizier,2,C+,3,Frank Karsten
+Merlin - Goat,2,C+,3,Frank Karsten
+Bashful - Hopeless Romantic,2,C+,3,Frank Karsten
+Queen of Hearts - Impulsive Ruler,2,C+,3,Frank Karsten
+Magic Broom - Industrial Model,2,C+,3,Frank Karsten
+Piglet - Very Small Animal,2,C+,3,Frank Karsten
+Blue Fairy - Rewarding Good Deeds,2,C+,3,Frank Karsten
+Panic - Underworld Imp,2,C+,3,Frank Karsten
+Minnie Mouse - Wide-Eyed Diver,2,C+,3,Frank Karsten
+Grand Duke - Advisor to the King,2,C+,3,Frank Karsten
+Rapunzel - Gifted Artist,2,C+,3,Frank Karsten
+Namaari - Morning Mist,2,C+,3,Frank Karsten
+Tiana - True Princess,2,C+,3,Frank Karsten
+Mulan - Free Spirit,2,C+,3,Frank Karsten
+Ratigan - Very Large Mouse,2,C+,3,Frank Karsten
+Doc - Leader of the Seven Dwarfs,2,C+,3,Frank Karsten
+Prince Charming - Heir to the Throne,2,C+,3,Frank Karsten
+Dr. Facilier - Savvy Opportunist,2,C+,3,Frank Karsten
+Teeth and Ambitions,2,C+,3,Frank Karsten
+Sneezy - Very Allergic,2,C+,3,Frank Karsten
+Chief Bogo - Respected Officer,2,C,3,Frank Karsten
+Enchantress - Unexpected Judge,2,C,3,Frank Karsten
+Kuzco - Wanted Llama,2,C,3,Frank Karsten
+Basil - Of Baker Street,2,C,3,Frank Karsten
+James - Role Model,2,C,3,Frank Karsten
+Mother Gothel - Withered and Wicked,2,C,3,Frank Karsten
+Eudora - Accomplished Seamstress,2,C,3,Frank Karsten
+Baloo - Fun-Loving Bear,2,C,3,Frank Karsten
+Prince Naveen - Penniless Royal,2,C,3,Frank Karsten
+Cheshire Cat - Always Grinning,2,C,3,Frank Karsten
+Caterpillar - Calm and Collected,2,C,3,Frank Karsten
+Minnie Mouse - Zipping Around,2,C,3,Frank Karsten
+Tigger - One of a Kind,2,C,3,Frank Karsten
+Basil - Perceptive Investigator,2,C,3,Frank Karsten
+Nothing to Hide,2,C,3,Frank Karsten
+Winnie The Pooh - Having a Think,2,C,3,Frank Karsten
+Nick Wilde - Wily Fox,2,C,3,Frank Karsten
+Benja - Guardian of the Dragon Gem,2,C,3,Frank Karsten
+Gumbo Pot,2,C,3,Frank Karsten
+Arthur - Trained Swordsman,2,C,3,Frank Karsten
+Robin Hood - Capable Fighter,2,C,3,Frank Karsten
+Eli La Bouff - Big Daddy,2,C,3,Frank Karsten
+Four Dozen Eggs,2,C,3,Frank Karsten
+Cinderella - Knight in Training,2,C,3,Frank Karsten
+Raya - Warrior of Kumandra,2,C,3,Frank Karsten
+Mouse Armor,2,C,3,Frank Karsten
+Go the Distance,2,C,3,Frank Karsten
+Pete - Bad Guy,2,C,3,Frank Karsten
+Flynn Rider - Confident Vagabond,2,C,3,Frank Karsten
+Tiana - Diligent Waitress,2,C,3,Frank Karsten
+Pinocchio - Star Attraction,2,C-,2,Frank Karsten
+Hiram Flaversham - Toymaker,2,C-,2,Frank Karsten
+Madam Mim - Rival of Merlin,2,C-,2,Frank Karsten
+Mickey Mouse - Friendly Face,2,C-,2,Frank Karsten
+Goofy - Knight for a Day,2,C-,2,Frank Karsten
+Legend of the Sword in the Stone,2,C-,2,Frank Karsten
+Last Cannon,2,C-,2,Frank Karsten
+Bounce,2,C-,2,Frank Karsten
+Last Stand,2,C-,2,Frank Karsten
+Judy Hopps - Optimistic Officer,2,C-,2,Frank Karsten
+Arthur - Wizard's Apprentice,2,C-,2,Frank Karsten
+Dinner Bell,2,C-,2,Frank Karsten
+The Huntsman - Reluctant Enforcer,2,C-,2,Frank Karsten
+Gaston - Baritone Bully,2,C-,2,Frank Karsten
+Merlin - Squirrel,2,C-,2,Frank Karsten
+Nana - Darling Family Pet,2,C-,2,Frank Karsten
+Bucky - Squirrel Squeak Tutor,2,C-,2,Frank Karsten
+Tiana - Celebrating Princess,2,C-,2,Frank Karsten
+Noi - Orphaned Thief,2,C-,2,Frank Karsten
+Hold Still,2,C-,2,Frank Karsten
+Jiminy Cricket - Pinocchio's Conscience,2,C-,2,Frank Karsten
+Belle - Bookworm,2,C-,2,Frank Karsten
+Pain - Underworld Imp,2,C-,2,Frank Karsten
+Dopey - Always Playful,2,C-,2,Frank Karsten
+Jasmine - Heir of Agrabah,2,C-,2,Frank Karsten
+Weight Set,2,C-,2,Frank Karsten
+Mulan - Reflecting,2,C-,2,Frank Karsten
+Pack Tactics,2,C-,2,Frank Karsten
+Duke Weaselton - Small-Time Crook,2,C-,2,Frank Karsten
+Gaston - Scheming Suitor,2,C-,2,Frank Karsten
+The Nokk - Water Spirit,2,D,1,Frank Karsten
+Raya - Headstrong,2,D,1,Frank Karsten
+Donald Duck - Sleepwalker,2,D,1,Frank Karsten
+I'm Stuck!,2,D,1,Frank Karsten
+You Can Fly!,2,D,1,Frank Karsten
+What did you call me?,2,D,1,Frank Karsten
+Merlin - Shapeshifter,2,D,1,Frank Karsten
+Fang Crossbow,2,D,1,Frank Karsten
+Cinderella - Ballroom Sensation,2,D,1,Frank Karsten
+Sardine Can,2,D,1,Frank Karsten
+Bibbidi Bobbidi Boo,2,D,1,Frank Karsten
+Prince John - Greediest of All,2,D,1,Frank Karsten
+Pick a Fight,2,D,1,Frank Karsten
+Launch,2,D,1,Frank Karsten
+Mrs. Judson - Housekeeper,2,D,1,Frank Karsten
+Queen of Hearts - Quick-Tempered,2,D,1,Frank Karsten
+Lady Tremaine - Overbearing Matriarch,2,D,1,Frank Karsten
+Snow White - Unexpected Houseguest,2,D,1,Frank Karsten
+Pinocchio - Talkative Puppet,2,D,1,Frank Karsten
+The Most Diabolical Scheme,2,D,1,Frank Karsten
+Dragon Gem,2,D,1,Frank Karsten
+The Sorcerer's Spellbook,2,D,1,Frank Karsten
+Honest John - Not That Honest,2,D,1,Frank Karsten
+The Queen - Disguised Peddler,2,D,1,Frank Karsten
+Falling Down the Rabbit Hole,2,D,1,Frank Karsten
+Gruesome And Grim,2,F,0,Frank Karsten
+Croquet Mallet,2,F,0,Frank Karsten
+Binding Contract,2,F,0,Frank Karsten
+Zero To Hero,2,F,0,Frank Karsten
+Sword In The Stone,2,F,0,Frank Karsten
+Perplexing Signposts,2,F,0,Frank Karsten
+Peter Pan's Dagger,2,F,0,Frank Karsten
+Sleepy's Flute,2,F,0,Frank Karsten
+Maurice's Workshop,2,F,0,Frank Karsten
+Ratigan's Marvelous Trap,2,F,0,Frank Karsten

--- a/draftmancer_custom_card_list_template.txt
+++ b/draftmancer_custom_card_list_template.txt
@@ -1,4892 +1,9796 @@
 [CustomCards]
 [
-    {
-        "name": "Scrooge Mcduck - Uncle Moneybags",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-155_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tiana's Palace - Jazz Restaurant",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-034_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scrooge McDuck - Richest Duck in the World",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-154_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pride Lands - Pride Rock",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-033_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Never Land - Mermaid Lagoon",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-032_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rufus - Orphanage Cat",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-153_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Wildcat's Wrench",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-031_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pluto - Mickey's Clever Friend",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-152_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Heart of Atlantis",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-030_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mama Odie - Mystical Maven",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-151_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maid Marian - Delightful Dreamer",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-150_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hydros - Ice Titan",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-039_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Distract",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-159_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Genie - Supportive Friend",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-038_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Wendy Darling - Authority on Peter Pan",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-158_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Diablo - Faithful Pet",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-037_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Very Clever Fairy",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-157_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chernabog's Followers - Creatures of Evil",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-036_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Alice - Tea Alchemist",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-035_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Mirror Seeker",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-156_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Wide-Eyed Diver",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-114_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Stylish Surfer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-113_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mother Gothel - Withered and Wicked",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-116_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Zipping Around",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-115_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Namaari - Nemesis",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-118_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mulan - Soldier in Training",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-117_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Queen of Hearts - Impulsive Ruler",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-119_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lady Tremaine - Imperious Queen",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-110_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lumiere - Hotheaded Candelabra",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-112_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lady Tremaine - Overbearing Matriarch",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-111_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Wendy Darling - Talented Sailor",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-023_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gyro Gearloose - Gadget Whiz",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-144_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Generous Fairy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-022_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gramma Tala - Spirit of the Ocean",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-143_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rolly - Hungry Pup",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-021_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gramma Tala - Keeper of Ancient Stories",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-142_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Queen of Hearts - Wonderland Empress",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-020_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Genie - Cramped in the Lamp",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-141_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flintheart Glomgold - Lone Cheater",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-140_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cleansing Rainwater",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-029_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Bare Necessities",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-028_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Louie - Chill Nephew",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-149_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Quick Patch",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-027_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kit Cloudkicker - Spunky Bear Cub",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-148_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Heal What Has Been Hurt",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-026_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kit Cloudkicker - Navigator",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-147_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Boss's Orders",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-025_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "King Louie - Bandleader",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-146_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "99 Puppies",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-024_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Huey - Savvy Nephew",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-145_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Baloo - Fun-Loving Bear",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-103_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ratigan's Marvelous Trap",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-102_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Card Soldiers - Full Deck",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-105_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Boun - Precocious Entrepreneur",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-104_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Felicia - Always Hungry",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-107_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Not Again!",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-106_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Honest John - Not That Honest",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-109_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fidget - Ratigan's Henchman",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-108_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ring the Bell",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-101_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pack Tactics",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-100_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sumerian Talisman",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-133_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nani - Protective Sister",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-012_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mr. Snoops - Inept Businessman",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-011_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui's Fish Hook",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-132_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Miss Bianca - Rescue Aid Society Agent",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-010_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Voyage",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-131_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "On Your Feet! Now!",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-130_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pongo - Determined Father",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-019_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pluto - Friendly Pooch",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-018_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dewey - Showy Nephew",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-139_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pluto - Determined Defender",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-017_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Amelia - First In Command",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-138_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Piglet - Pooh Pirate Captain",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-016_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Audrey Ramirez - The Engineer",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-137_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Perdita - Devoted Mother",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-015_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "RLS Legacy - Solar Galleon",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-136_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jolly Roger - Hook's Ship",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-135_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Patch - Intimidating Pup",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-014_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Agrabah - Marketplace",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-134_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Orville - Ace Pilot",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-013_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scroop - Backstabber",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-122_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Baloo - von Bruinwald XIII",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-001_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince Eric - Expert Helmsman",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-121_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan - Pirate's Bane",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-120_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Musical Artist",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-009_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "I've Got a Dream",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-129_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lucky - The 15th Puppy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-008_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Divebomb",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-128_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kida - Protector of Atlantis",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-007_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kida - Atlantean",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-006_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Webby Vanderquack - Enthusiastic Duck",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-127_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Trigger - Not-So-Sharp Shooter",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-126_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Joshua Sweet - The Doctor",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-005_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - Little Rocket",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-125_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Slightly - Lost Boy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-124_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chernabog - Evildoer",
-        "mana_cost": "{10}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-003_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Scrappy Cub",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-123_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bernard - Brand-New Agent",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-002_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Last Cannon",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-202_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Strength of a Raging Fire",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-201_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Weight Set",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-204_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mouse Armor",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-203_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pick a Fight",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-200_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kakamora - Menacing Sailor",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-111_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jim Hawkins - Thrill Seeker",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-110_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan - Never Land Hero",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-119_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nutsy - Vulture Henchman",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-118_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Moana - Undeterred Voyager",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-117_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Moana - Born Leader",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-116_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Milo Thatch - Spirited Scholar",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-115_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui - Whale",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-114_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui - Soaring Demigod",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-113_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Madame Medusa - The Boss",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-112_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jim Hawkins - Space Traveler",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-109_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "De Vil Manor - Cruella's Estate",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-100_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hydra - Deadly Serpent",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-108_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "HeiHei - Accidental Explorer",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-107_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Della Duck - Unstoppable Mom",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-106_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook - Master Swordsman",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-105_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Billy Bones - Keeper of the Map",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-104_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ariel - Adventurous Collector",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-103_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kuzco's Palace - Home of the Emperor",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-102_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fang - River City",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-101_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Bayou - Mysterious Swamp",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-204_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nottingham - Prince John's Castle",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-203_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui's Place of Exile - Hidden Island",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-202_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Map of Treasure Planet",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-201_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gizmosuit",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-200_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Megara - Pulling the Strings",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-087_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mad Hatter - Gracious Host",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-086_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lady Tremaine - Wicked Stepmother",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-085_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kuzco - Temperamental Emperor",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-084_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Steamboat Pilot",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-089_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Artful Rogue",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-088_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jumba Jookiba - Renegade Scientist",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-083_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "John Silver - Alien Pirate",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-082_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jasper - Common Crook",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-081_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Iago - Loud-Mouthed Parrot",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-080_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sudden Chill",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-098_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Steal from the Rich",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-097_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stampede",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-096_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mother Knows Best",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-095_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Beast is Mine!",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-099_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mother Gothel - Selfish Manipulator",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-090_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Do It Again!",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-094_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Most Helpful",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-093_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tamatoa - Drab Little Crab",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-092_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan - Never Landing",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-091_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Reflection",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-065_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Musketeer",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-186_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Friends on the Other Side",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-064_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui - Demigod",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-185_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Freeze",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-063_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lilo - Galactic Hero",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-184_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Befuddle",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-062_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kronk - Right-Hand Man",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-183_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aladdin - Prince Ali",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-069_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "White Rabbit's Pocket Watch",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-068_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Returned King",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-189_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula's Cauldron",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-067_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Future King",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-188_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Mirror",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-066_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince Eric - Dashing and Brave",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-187_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Zeus - God of Lightning",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-061_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kristoff - Official Ice Master",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-182_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Yzma - Alchemist",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-060_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hercules - True Hero",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-181_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hans - Thirteenth in Line",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-180_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fire the Cannons!",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-197_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Genie - Powers Unleashed",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-076_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Break",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-196_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Genie - On the Job",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-075_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "A Whole New World",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-195_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flynn Rider - Charming Rogue",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-074_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Tiny Tactician",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-194_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Duke of Weselton - Opportunistic Official",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-073_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Horace - No-Good Scoundrel",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-079_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ransack",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-199_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hans - Scheming Prince",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-078_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Grab Your Sword",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-198_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Genie - The Ever Impressive",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-077_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Giant Fairy",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-193_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cruella De Vil - Miserable as Usual",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-072_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Te K\u0101 - Heartless",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-192_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cheshire Cat - Not All There",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-071_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Starkey - Hook's Henchman",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-191_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Wolfsbane",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-070_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Rightful Heir",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-190_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Sorceress",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-049_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Biding Her Time",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-048_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Golden Flower",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-169_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ratigan - Criminal Mastermind",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-091_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Queen of Hearts - Quick-Tempered",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-090_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Disguised Peddler",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-093_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ray - Easygoing Firefly",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-092_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flotsam - Ursula's Spy",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-043_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "One Jump Ahead",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-164_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Elsa - Spirit of Winter",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-042_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Let It Go",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-163_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Elsa - Snow Queen",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-041_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "If it's Not Baroque",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-162_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Elsa - Queen Regent",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-040_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Develop Your Brain",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-161_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Broom - Bucket Brigade",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-047_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fishbone Quill",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-168_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jetsam - Ursula's Spy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-046_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Eye of the Fates",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-167_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Wicked Sorcerer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-045_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Coconut Basket",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-166_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Keeper of Secrets",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-044_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Work Together",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-165_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Triton - The Sea King",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-160_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Virana - Fang Chief",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-095_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tiana - True Princess",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-094_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bounce",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-097_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bibbidi Bobbidi Boo",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-096_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Improvise",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-099_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hypnotize",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-098_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula - Power Hungry",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-059_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Enchantress - Unexpected Judge",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-080_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flynn Rider - His Own Biggest Fan",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-082_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flynn Rider - Confident Vagabond",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-081_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rafiki - Mysterious Sage",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-054_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook - Thinking a Happy Thought",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-175_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pascal - Rapunzel's Companion",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-053_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook - Forceful Duelist",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-174_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Olaf - Friendly Snowman",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-052_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook - Captain of the Jolly Roger",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-173_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Wayward Sorcerer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-051_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Hardheaded",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-172_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tinker Bell - Peter Pan's Ally",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-058_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Goons - Maleficent's Underlings",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-179_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Wardrobe - Belle's Confidant",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-057_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gantu - Galactic Federation Captain",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-178_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Wicked and Vain",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-056_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Musketeer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-177_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sven - Official Ice Deliverer",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-055_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cerberus - Three-Headed Dog",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-176_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dalmatian Puppy - Tail Wagger",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-004b_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Marshmallow - Persistent Guardian",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-050_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aladdin - Cornered Swordsman",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-171_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scepter of Arendelle",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-170_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Little John - Loyal Friend",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-084_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gaston - Scheming Suitor",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-083_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pain - Underworld Imp",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-086_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lucifer - Cunning Cat",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-085_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pete - Bad Guy",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-088_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Panic - Underworld Imp",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-087_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince John - Greediest of All",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-089_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Just in Time",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-029_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Healing Glow",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-028_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jasmine - Queen of Agrabah",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-149_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hakuna Matata",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-027_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jasmine - Disguised",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-148_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Control Your Temper!",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-026_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hades - Infernal Schemer",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-147_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pacha - Village Leader",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-190_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Queen of Hearts - Capricious Monarch",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-192_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Belle - Bookworm",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-071_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince Naveen - Penniless Royal",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-191_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Relentless",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-070_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - Carefree Surfer",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-206_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Belle - Strange but Special",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-142_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Protective Cub",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-020_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Belle - Inventive Engineer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-141_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aurora - Regal Princess",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-140_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Be Our Guest",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-025_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gramma Tala - Storyteller",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-146_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Timon - Grub Rustler",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-024_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flounder - Voice of Reason",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-145_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - Rock Star",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-023_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Strutting His Stuff",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-144_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - New Dog",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-022_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chief Tui - Respected Leader",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-143_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Huntsman - Reluctant Enforcer",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-194_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bucky - Squirrel Squeak Tutor",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-073_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin Hood - Capable Fighter",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-193_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Belle - Hidden Archer",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-072_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tiana - Celebrating Princess",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-196_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cheshire Cat - From the Shadows",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-075_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Prince - Never Gives Up",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-195_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cheshire Cat - Always Grinning",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-074_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Charge!",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-198_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Perfect Gentleman",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-077_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tiana - Diligent Waitress",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-197_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Daisy Duck - Secret Agent",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-076_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier - Fortune Teller",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-079_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Let the Storm Rage On",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-199_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Sleepwalker",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-078_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier - Remarkable Gentleman",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-039_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier - Charlatan",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-038_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tamatoa - So Shiny!",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-159_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier - Agent Provocateur",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-037_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scar - Mastermind",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-158_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Yzma - Scary Beyond All Reason",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-060_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hercules - Divine Hero",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-181_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Goofy - Knight for a Day",
-        "mana_cost": "{9}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-180_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Self-Appointed Mentor",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-153_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "You Have Forgotten Me",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-031_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maurice - World-Famous Inventor",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-152_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Part of Your World",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-030_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Uninvited",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-151_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Sinister Visitor",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-150_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Archimedes - Highly Educated Owl",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-036_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin Hood - Unrivaled Archer",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-157_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Anna - Heir to Arendelle",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-035_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Philoctetes - Trainer of Heroes",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-156_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula's Shell Necklace",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-034_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mufasa - King of the Pride Lands",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-155_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lantern",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-033_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Detective",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-154_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Arthur - Trained Swordsman",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-069_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gruesome and Grim",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-062_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Dreadnought",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-183_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Yzma - Without Beauty Sleep",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-061_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hercules - Hero in Training",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-182_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Legend of the Sword in the Stone",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-064_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kronk - Junior Chipmunk",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-185_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "I'm Stuck!",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-063_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Royal Vizier",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-184_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Croquet Mallet",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-066_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Li Shang - Archery Instructor",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-187_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Binding Contract",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-065_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lawrence - Jealous Manservant",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-186_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Sorcerer's Spellbook",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-068_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Namaari - Morning Mist",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-189_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Perplexing Signposts",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-067_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Broom - Industrial Model",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-188_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "HeiHei - Boat Snack",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-007_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Be Prepared",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-128_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hades - Lord of the Underworld",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-006_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tigger - Wonderful Thing",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-127_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Starlight Vial",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-099_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hades - King of Olympus",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-005_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Te K\u0101 - The Burning One",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-126_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin's Bow",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-098_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Goofy - Musketeer",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-004_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - Abomination",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-125_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Airfoil",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-097_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Strike A Good Match",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-096_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "I Will Find My Way",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-095_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lilo - Making a Wish",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-009_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sardine Can",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-170_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Has Set My Heaaaaaaart . . .",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-094_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "LeFou - Bumbler",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-008_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cut to the Chase",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-129_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Zazu - Steward of the Pride Lands",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-093_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pongo - Ol' Rascal",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-120_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cinderella - Gentle and Kind",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-003_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sergeant Tibbs - Courageous Cat",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-124_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ariel - Spectacular Singer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-002_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scar - Shameless Firebrand",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-123_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ariel - On Human Legs",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-001_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scar - Fiery Usurper",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-122_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rapunzel - Letting Down Her Hair",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-121_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Winnie the Pooh - Hunny Wizard",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-059_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pinocchio - Talkative Puppet",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-058_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Eli La Bouff - Big Daddy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-179_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Goat",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-051_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Selfless Protector",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-172_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Wildcat - Mechanic",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-092_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Crab",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-050_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Forbidding Recluse",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-171_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula - Deceiver of All",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-091_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Shapeshifter",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-053_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Benja - Guardian of the Dragon Gem",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-174_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula - Deceiver",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-090_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Rabbit",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-052_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast - Tragic Hero",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-173_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan's Shadow - Not Sewn On",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-055_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cinderella - Knight in Training",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-176_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Merlin - Squirrel",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-054_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chief Bogo - Respected Officer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-175_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pinocchio - On the Run",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-057_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Deep-Sea Diver",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-178_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pinocchio - Star Attraction",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-056_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cinderella - Stouthearted",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-177_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rapunzel - Gifted with Healing",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-018_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aurora - Dreaming Guardian",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-139_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stitch - Covert Agent",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-089_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pumbaa - Friendly Warthog",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-017_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aurora - Briar Rose",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-138_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Starkey - Devious Pirate",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-088_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince Phillip - Dragonslayer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-016_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ariel - Whoseit Collector",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-137_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Skippy - Energetic Rabbit",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-087_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mr. Smee - Loyal First Mate",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-015_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sword of Truth",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-136_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sir Hiss - Aggravating Asp",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-086_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Shenzi - Hyena Pack Leader",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-085_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin Hood - Daydreamer",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-084_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince John - Phony King",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-083_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sebastian - Court Composer",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-019_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan - Lost Boy Leader",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-082_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maximus - Palace Horse",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-010_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fan the Flames",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-131_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dragon Fire",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-130_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Moana - Of Motunui",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-014_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Shield of Virtue",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-135_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Beloved Princess",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-013_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Poisoned Apple",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-134_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - True Friend",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-012_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tangle",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-133_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maximus - Relentless Pursuer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-011_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "He's Got a Sword!",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-132_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Madam Mim - Rival of Merlin",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-048_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pawpsicle",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-169_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Madam Mim - Purple Dragon",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-047_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maurice's Workshop",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-168_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Madam Mim - Snake",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-049_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fairy Godmother - Here to Help",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-040_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Winnie the Pooh - Having a Think",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-161_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Morph - Space Goo",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-081_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Nokk - Water Spirit",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-160_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Milo Thatch - King of Atlantis",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-080_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fairy Godmother - Pure Heart",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-042_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Four Dozen Eggs",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-163_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fairy Godmother - Mystic Armorer",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-041_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Falling Down the Rabbit Hole",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-162_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jiminy Cricket - Pinocchio's Conscience",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-044_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nothing to Hide",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-165_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "HeiHei - Persistent Presence",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-043_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Launch",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-164_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Madam Mim - Fox",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-046_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gumbo Pot",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-167_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kuzco - Wanted Llama",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-045_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Fang Crossbow",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-166_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain - Colonel's Lieutenant",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-106_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lyle Tiberius Rourke - Cunning Mercenary",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-078_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook's Rapier",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-199_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aladdin - Street Rat",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-105_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rise of the Titans",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-198_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kit Cloudkicker - Tough Guy",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-077_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aladdin - Heroic Outlaw",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-104_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jetsam - Riffraff",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-076_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Olympus Would Be That Way",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-197_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Abu - Mischievous Monkey",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-103_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Helga Sinclair - Vengeful Partner",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-075_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ba-boom!",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-196_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Helga Sinclair - Femme Fatale",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-074_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "And Then Along Came Zeus",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-195_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Elsa - Ice Surfer",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-109_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Friar Tuck - Priest Of Nottingham",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-073_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Thaddeus E. Klang - Metallic Leader",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-194_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Donald Duck - Boisterous Fowl",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-108_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Flotsam - Riffraff",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-072_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Rightful King",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-193_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Captain Hook - Ruthless Pirate",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-107_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Don Karnage - Prince of Pirates",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-071_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Simba - Fighting Prince",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-192_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stolen Scimitar",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-102_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier's Cards",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-101_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Vicious Betrayal",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-100_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Milo Thatch - Clever Cartographer",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-079_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chip the Teacup - Gentle Soul",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-037_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rabbit - Reluctant Host",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-158_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Blue Fairy - Rewarding Good Deeds",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-036_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Prince Charming - Heir to the Throne",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-157_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Elsa - Gloves Off",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-039_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dr. Facilier - Savvy Opportunist",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-038_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sisu - Divine Water Dragon",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-159_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "James - Role Model",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-150_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sheriff of Nottingham - Corrupt Official",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-191_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cursed Merfolk - Ursula's Handiwork",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-070_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin Hood - Champion of Sherwood",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-190_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "World's Greatest Criminal Mind",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-031_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Judy Hopps - Optimistic Officer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-152_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Painting the Roses Red",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-030_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jasmine - Heir of Agrabah",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-151_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dragon Gem",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-033_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nick Wilde - Wily Fox",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-154_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Zero to Hero",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-032_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mrs. Judson - Housekeeper",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-153_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Arthur - Wizard's Apprentice",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-035_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Owl - Logical Lecturer",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-156_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sleepy's Flute",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-034_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Noi - Orphaned Thief",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-155_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Moana - Chosen by the Ocean",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-117_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen's Castle - Mirror Chamber",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-067_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Razoul - Palace Guard",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-188_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Always Classy",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-116_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Forbidden Mountain - Maleficent's Castle",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-066_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pyros - Lava Titan",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-187_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Brave Little Tailor",
-        "mana_cost": "{8}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-115_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Sorcerer's Hat",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-065_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nala - Fierce Friend",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-186_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maui - Hero to All",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-114_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Lamp",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-064_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mufasa - Champion of the Pride Lands",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-185_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mr. Smee - Bumbling Mate",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-184_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Boss Is On A Roll",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-063_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Minnie Mouse - Funky Spelunker",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-183_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Last-Ditch Effort",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-062_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan - Fearless Fighter",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-119_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "It Calls Me",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-061_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Trumpeter",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-182_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mulan - Imperial Soldier",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-118_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bestow a Gift",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-060_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Stalwart Explorer",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-181_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Monstrous Dragon",
-        "mana_cost": "{9}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-113_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "LeFou - Instigator",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-112_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Goofy - Daredevil",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-111_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cubby - Mighty Lost Boy",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-069_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gaston - Arrogant Hunter",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-110_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Robin Hood - Beloved Outlaw",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-189_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Sorcerer's Tower - Wondrous Workspace",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-068_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Commanding Presence",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-026_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gaston - Intellectual Powerhouse",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-147_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Snow White - Well Wisher",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-025_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Duke Weaselton - Small-Time Crook",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-146_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hold Still",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-028_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hiram Flaversham - Toymaker",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-149_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Regal Monarch",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-027_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Grand Pabbie - Oldest and Wisest",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-148_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Last Stand",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-029_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lythos - Rock Titan",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-180_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rapunzel - Sunshine",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-020_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Caterpillar - Calm and Collected",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-141_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Basil - Perceptive Investigator",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-140_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sneezy - Very Allergic",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-022_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cogsworth - Talking Clock",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-143_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sleepy - Nodding Off",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-021_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cogsworth - Grandfather Clock",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-142_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Snow White - Unexpected Houseguest",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-024_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cruella De Vil - Perfectly Wretched",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-145_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Snow White - Lost in the Forest",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-023_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cruella De Vil - Fashionable Cruiser",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-144_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Firebird - Force of Destruction",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-056_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Kida - Royal Warrior",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-177_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Plasma Blaster",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-204_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Stratos - Tornado Titan",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-055_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "John Silver - Greedy Treasure Seeker",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-176_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Musketeer Tabard",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-203_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Helga Sinclair - Right-Hand Woman",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-175_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rafiki - Mystical Fighter",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-054_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Frying Pan",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-202_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Hades - Hotheaded Ruler",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-174_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Pua - Potbellied Buddy",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-053_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mama Odie - Voice of Wisdom",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-052_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gustav The Giant - Terror of the Kingdom",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-173_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Maleficent - Mistress of All Evil",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-051_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Eeyore - Overstuffed Donkey",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-172_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magica De Spell - Thieving Sorceress",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-050_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Chief Tui - Proud of Motunui",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-171_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Motunui - Island Paradise",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-170_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Beast's Mirror",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-201_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Smash",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/001-200_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ursula - Sea Witch",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-059_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Treasure Guardian - Protector of the Cave",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-058_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Little John - Robin's Pal",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-179_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Little John - Resourceful Outlaw",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-178_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Queen - Hateful Rival",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-057_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mulan - Free Spirit",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-015_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Sword in the Stone",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-136_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mufasa - Betrayed Leader",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-014_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Peter Pan's Dagger",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-135_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Nana - Darling Family Pet",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-017_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Basil - Great Mouse Detective",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-138_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mulan - Reflecting",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-016_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Alice - Growing Girl",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-137_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Rapunzel - Gifted Artist",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-019_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Piglet - Very Small Animal",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-018_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Basil - Of Baker Street",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-139_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Teeth and Ambitions",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-130_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Happy - Good-Natured",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-011_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "What Did You Call Me?",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-132_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Grumpy - Bad-Tempered",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-010_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "The Most Diabolical Scheme",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-131_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Mickey Mouse - Friendly Face",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-013_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dinner Bell",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-134_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "King Louie - Jungle VIP",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-012_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "You Can Fly!",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-133_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scrooge's Top Hat",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-166_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Broom - Swift Cleaner",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-045_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lucky Dime",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-165_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Broom - Dancing Duster",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-044_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Lena Sabrewing - Rebellious Teenager",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-043_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Heart of Te Fiti",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-164_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Striking Illusionist",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-042_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Aurelian Gyrosensor",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-163_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Repair",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-162_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Jafar - Lamp Thief",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-041_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Iago - Pretty Polly",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-040_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "How Far I'll Go",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-161_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Friend Like Me",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-160_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magica De Spell - The Midas Touch",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-049_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magica De Spell - Ambitious Witch",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-048_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "McDuck Manor - Scrooge's Mansion",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-169_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Carpet - Flying Rug",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-047_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Belle's House - Maurice's Workshop",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-168_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Vault Door",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-167_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Magic Broom - The Big Sweeper",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/003-046_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cobra Bubbles - Just a Social Worker",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-004_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Scar - Vicious Cheater",
-        "mana_cost": "{7}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-125_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Cinderella - Ballroom Sensation",
-        "mana_cost": "{1}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-003_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Raya - Warrior of Kumandra",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-124_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Dopey - Always Playful",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-006_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tigger - One of a Kind",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-127_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Doc - Leader of the Seven Dwarfs",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-005_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Shere Khan - Menacing Predator",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-126_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Gaston - Baritone Bully",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-008_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Go the Distance",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-129_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Eudora - Accomplished Seamstress",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-007_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Tuk Tuk - Wrecking Ball",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-128_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Grand Duke - Advisor to the King",
-        "mana_cost": "{2}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-009_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Ratigan - Very Large Mouse",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-121_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Queen of Hearts - Sensing Weakness",
-        "mana_cost": "{5}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-120_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Christopher Robin - Adventurer",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-002_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Raya - Leader of Heart",
-        "mana_cost": "{6}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-123_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Bashful - Hopeless Romantic",
-        "mana_cost": "{4}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-001_716x1000.jpeg"
-        }
-    },
-    {
-        "name": "Raya - Headstrong",
-        "mana_cost": "{3}",
-        "type": "Instant",
-        "image_uris": {
-            "en": "https://images.dreamborn.ink/cards/en/tts/002-122_716x1000.jpeg"
-        }
+     {
+       "name": "The Bayou - Mysterious Swamp",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-204_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Weight Set",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-204_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Plasma Blaster",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-204_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Thebes - The Big Olive",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-204_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mouse Armor",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-203_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "The Wall - Border Fortress",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-203_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Musketeer Tabard",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-203_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Nottingham - Prince John's Castle",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-203_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Frying Pan",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-202_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "RLS Legacy's Cannon",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-202_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maui's Place of Exile - Hidden Island",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-202_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Last Cannon",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-202_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Imperial Bow",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-201_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Map of Treasure Planet",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-201_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Strength of a Raging Fire",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-201_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Beast's Mirror",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-201_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pick a Fight",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-200_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Smash",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-200_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Fortisphere",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-200_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Gizmosuit",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-200_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Captain Hook's Rapier",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-199_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ransack",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-199_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Triton's Decree",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-199_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Let the Storm Rage On",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-199_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "The Mob Song",
+       "mana_cost": "{10}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-198_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rise of the Titans",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-198_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Grab Your Sword",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-198_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Charge!",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-198_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "One Last Hope",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-197_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Olympus Would Be That Way",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-197_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tiana - Diligent Waitress",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-197_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Fire the Cannons!",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-197_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "I Find 'Em, I Flatten 'Em",
+       "mana_cost": "{4}" ,
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-196_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tiana - Celebrating Princess",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-196_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ba-Boom!",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-196_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Break",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-196_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Avalanche",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-195_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Prince - Never Gives Up",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-195_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "A Whole New World",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-195_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "And Then Along Came Zeus",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-195_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Thaddeus E. Klang - Metallic Leader",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-194_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Huntsman - Reluctant Enforcer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-194_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Yao - Imperial Soldier",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-194_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tinker Bell - Tiny Tactician",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-194_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Simba - Rightful King",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-193_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Robin Hood - Capable Fighter",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-193_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Raya - Unstoppable Force",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-193_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tinker Bell - Giant Fairy",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-193_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Simba - Fighting Prince",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-192_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Rajah - Royal Protector",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-192_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Queen of Hearts - Capricious Monarch",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-192_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Te Ka - Heartless",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-192_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Starkey - Hook's Henchman",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-191_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Sheriff of Nottingham - Corrupt Official",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-191_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Piglet - Sturdy Swordsman",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-191_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Prince Naveen - Penniless Royal",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-191_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Pacha - Village Leader",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-190_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Simba - Rightful Heir",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-190_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Philoctetes - No-Nonsense Instructor",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-190_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Robin Hood - Champion of Sherwood",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-190_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mulan - Armored Fighter",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-189_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Simba - Returned King",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-189_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Namaari - Morning Mist",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-189_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Robin Hood - Beloved Outlaw",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-189_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mickey Mouse - Standard Bearer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-188_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Razoul - Palace Guard",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-188_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Magic Broom - Industrial Model",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-188_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Simba - Future King",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-188_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Li Shang - Archery Instructor",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-187_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mickey Mouse - Playful Sorcerer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-187_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pyros - Lava Titan",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-187_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Prince Eric - Dashing and Brave",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-187_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Nala - Fierce Friend",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-186_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Lawrence - Jealous Manservant",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-186_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Magic Broom - Brigade Commander",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-186_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Musketeer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-186_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mufasa - Champion of the Pride Lands",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-185_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Kronk - Junior Chipmunk",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-185_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Maui - Demigod",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-185_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Magic Broom - Aerial Cleaner",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-185_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mr. Smee - Bumbling Mate",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-184_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Lilo - Galactic Hero",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-184_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Luisa Madrigal - Rock of the Family",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-184_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jafar - Royal Vizier",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-184_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ling - Imperial Soldier",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-183_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jafar - Dreadnought",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-183_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Kronk - Right-Hand Man",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-183_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Minnie Mouse - Funky Spelunker",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-183_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Li Shang - Imperial Captain",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-182_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Trumpeter",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-182_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hercules - Hero in Training",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-182_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Kristoff - Official Ice Master",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-182_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Lefou - Opportunistic Flunky",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-181_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Hercules - Divine Hero",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-181_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mickey Mouse - Stalwart Explorer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-181_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hercules - True Hero",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-181_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Lythos - Rock Titan",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-180_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hans - Thirteenth in Line",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-180_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Hercules - Beloved Hero",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-180_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Goofy - Knight for a Day",
+       "mana_cost": "{9}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-180_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Little John - Robin's Pal",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-179_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Eli La Bouff - Big Daddy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-179_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Donald Duck - Buccaneer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-179_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Goons - Maleficent's Underlings",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-179_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Little John - Resourceful Outlaw",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-178_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Gantu - Galactic Federation Captain",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-178_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Chien-Po - Imperial Soldier",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-178_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Donald Duck - Deep-Sea Diver",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-178_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Chi-Fu - Imperial Advisor",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-177_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Donald Duck - Musketeer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-177_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cinderella - Stouthearted",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-177_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Kida - Royal Warrior",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-177_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "John Silver - Greedy Treasure Seeker",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-176_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Beast - Thick-Skinned",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-176_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cinderella - Knight in Training",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-176_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Cerberus - Three-Headed Dog",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-176_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ariel - Sonic Warrior",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-175_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Chief Bogo - Respected Officer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-175_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Captain Hook - Thinking a Happy Thought",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-175_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Helga Sinclair - Right-Hand Woman",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-175_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hades - Hotheaded Ruler",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-174_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ariel - Determined Mermaid",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-174_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Benja - Guardian of the Dragon Gem",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-174_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Captain Hook - Forceful Duelist",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-174_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gustav the Giant - Terror of the Kingdom",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-173_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Captain Hook - Captain of the Jolly Roger",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-173_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Beast - Tragic Hero",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-173_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Arges - The Cyclops",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-173_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Beast - Hardheaded",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-172_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Beast - Selfless Protector",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": [],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-172_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Aladdin - Resolute Swordsman",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-172_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Eeyore - Overstuffed Donkey",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-172_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Aladdin - Brave Rescuer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-171_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Chief Tui - Proud of Motunui",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-171_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Beast - Forbidding Recluse",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-171_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Aladdin - Cornered Swordsman",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": [],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-171_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Sorcerer's Tower - Wondrous Workspace",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-068_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ursula's Lair - Eye of the Storm",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-068_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Sorcerer's Spellbook",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-068_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "White Rabbit's Pocket Watch",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-068_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ursula's Cauldron",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-067_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Queen's Castle - Mirror Chamber",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-067_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Perplexing Signposts",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-067_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Casa Madrigal - Casita",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-067_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Triton's Trident",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-066_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magic Mirror",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-066_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Forbidden Mountain - Maleficent's Castle",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-066_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Croquet Mallet",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-066_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Binding Contract",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-065_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Reflection",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-065_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Sorcerer's Hat",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-065_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Rose Lantern",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-065_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mystical Rose",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-064_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Lamp",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-064_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Legend of the Sword in the Stone",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-064_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Friends On The Other Side",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-064_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ursula's Plan",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-063_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Boss Is on a Roll",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-063_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "I'm Stuck!",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-063_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Freeze",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-063_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Last-Ditch Effort",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-062_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Befuddle",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-062_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gruesome And Grim",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-062_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Swing Into Action",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-062_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "It Calls Me",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-061_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Yzma - Without Beauty Sleep",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-061_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Second Star To The Right",
+       "mana_cost": "{10}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-061_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Zeus - God of Lightning",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-061_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Yzma - Scary Beyond All Reason",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-060_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Poor Unfortunate Souls",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-060_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Bestow a Gift",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-060_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Yzma - Alchemist",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-060_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ursula - Sea Witch",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-059_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Yen Sid - Powerful Sorcerer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-059_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ursula - Power Hungry",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-059_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Winnie The Pooh - Hunny Wizard",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-059_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Pinocchio - Talkative Puppet",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-058_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Treasure Guardian - Protector of the Cave",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-058_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ursula - Sea Witch Queen",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-058_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tinker Bell - Peter Pan's Ally",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-058_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ursula - Mad Sea Witch",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-057_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pinocchio - On the Run",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-057_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "The Queen - Hateful Rival",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-057_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Wardrobe - Belle's Confidant",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-057_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Queen - Wicked and Vain",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-056_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pinocchio - Star Attraction",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-056_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tick-Tock - Ever-Present Pursuer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-056_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Firebird - Force of Destruction",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-056_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Sven - Official Ice Deliverer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-055_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Peter Pan's Shadow - Not Sewn On",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-055_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Stratos - Tornado Titan",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-055_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pico - Helpful Toucan",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-055_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rafiki - Mysterious Sage",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-054_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Peter Pan - Shadow Finder",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-054_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rafiki - Mystical Fighter",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-054_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Merlin - Squirrel",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-054_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Pascal - Rapunzel's Companion",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-053_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pepa Madrigal - Weather Maker",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-053_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Merlin - Shapeshifter",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-053_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Pua - Potbellied Buddy",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-053_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mama Odie - Voice of Wisdom",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-052_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Olaf - Friendly Snowman",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-052_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mrs. Potts - Enchanted Teapot",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-052_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Merlin - Rabbit",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-052_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Marshmallow - Terrifying Snowman",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-051_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Merlin - Goat",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-051_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mickey Mouse - Wayward Sorcerer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-051_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Maleficent - Mistress of All Evil",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-051_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Magical Maid - Feather Duster",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-050_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magica De Spell - Thieving Sorceress",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-050_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Marshmallow - Persistent Guardian",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-050_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Merlin - Crab",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-050_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Madam Mim - Snake",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-049_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Magica De Spell - The Midas Touch",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-049_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Magic Broom - Lively Sweeper",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-049_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maleficent - Sorceress",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-049_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Madam Mim - Rival of Merlin",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-048_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Maleficent - Biding Her Time",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-048_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Magic Broom - Illuminary Keeper",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-048_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magica De Spell - Ambitious Witch",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-048_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Madam Mim - Purple Dragon",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-047_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Luisa Madrigal - Magically Strong One",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-047_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magic Carpet - Flying Rug",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-047_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Magic Broom - Bucket Brigade",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-047_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Madam Mim - Fox",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-046_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jetsam - Ursula's \"Baby\"",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-046_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magic Broom - The Big Sweeper",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-046_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Jetsam - Ursula's Spy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-046_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Isabela Madrigal - Golden Child",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-045_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magic Broom - Swift Cleaner",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-045_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Kuzco - Wanted Llama",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-045_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jafar - Wicked Sorcerer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-045_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Flotsam & Jetsam - Entangling Eels",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-044_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Magic Broom - Dancing Duster",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-044_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Jafar - Keeper of Secrets",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-044_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Jiminy Cricket - Pinocchio's Conscience",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-044_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Flotsam - Ursula's \"Baby\"",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-043_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "HeiHei - Persistent Presence",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-043_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Flotsam - Ursula's Spy",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-043_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Lena Sabrewing - Rebellious Teenager",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-043_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Elsa - Storm Chaser",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-042_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jafar - Striking Illusionist",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-042_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Elsa - Spirit of Winter",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-042_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Fairy Godmother - Pure Heart",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-042_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jafar - Lamp Thief",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-041_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Elsa - Snow Queen",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-041_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Fairy Godmother - Mystic Armorer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-041_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dolores Madrigal - Easy Listener",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-041_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Camilo Madrigal - Prankster",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-040_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Fairy Godmother - Here to Help",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-040_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Iago - Pretty Polly",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-040_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Elsa - Queen Regent",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-040_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Hydros - Ice Titan",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-039_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Bruno Madrigal - Undetected Uncle",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-039_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Dr. Facilier - Remarkable Gentleman",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-039_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Elsa - Gloves Off",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-039_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Genie - Supportive Friend",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-038_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Bruno Madrigal - Out of the Shadows",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-038_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Dr. Facilier - Savvy Opportunist",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-038_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dr. Facilier - Charlatan",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-038_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Dr. Facilier - Agent Provocateur",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-037_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Belle - Untrained Mystic",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-037_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Diablo - Faithful Pet",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-037_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Chip the Teacup - Gentle Soul",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-037_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Chernabog's Followers - Creatures of Evil",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-036_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Blue Fairy - Rewarding Good Deeds",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-036_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Belle - Accomplished Mystic",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-036_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Archimedes - Highly Educated Owl",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-036_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Antonio Madrigal - Animal Expert",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-035_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Anna - Heir to Arendelle",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["B"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-035_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Alice - Tea Alchemist",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-035_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Arthur - Wizard's Apprentice",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["B"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-035_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tiana's Palace - Jazz Restaurant",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-034_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Underworld - River Styx",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-034_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sleepy's Flute",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-034_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ursula's Shell Necklace",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-034_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pride Lands - Pride Rock",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-033_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Dragon Gem",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-033_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lantern",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-033_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Atlantica - Concert Hall",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-033_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Zero To Hero",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-032_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Record Player",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-032_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Never Land - Mermaid Lagoon",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-032_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Dinglehopper",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-032_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Wildcat's Wrench",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-031_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "You Have Forgotten Me",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-031_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Miracle Candle",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-031_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "World's Greatest Criminal Mind",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-031_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Sign The Scroll",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-030_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Heart of Atlantis",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-030_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Part of Your World",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-030_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Painting the Roses Red",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-030_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lost in the Woods",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-029_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Last Stand",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-029_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Just in Time",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-029_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cleansing Rainwater",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-029_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Look At This Family",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-028_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Bare Necessities",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-028_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hold Still",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-028_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Healing Glow",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-028_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "First Aid",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-027_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Quick Patch",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-027_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Queen - Regal Monarch",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-027_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hakuna Matata",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-027_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Bruno's Return",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-026_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Queen - Commanding Presence",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-026_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Heal What Has Been Hurt",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-026_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Control Your Temper!",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-026_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Be Our Guest",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-025_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Snow White - Well Wisher",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-025_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ursula - Vanessa",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-025_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Boss's Orders",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-025_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "99 Puppies",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-024_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Snow White - Unexpected Houseguest",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-024_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ursula - Eric's Bride",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-024_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Timon - Grub Rustler",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-024_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Wendy Darling - Talented Sailor",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-023_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Stitch - Rock Star",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-023_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Stitch - Alien Dancer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-023_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Snow White - Lost in the Forest",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-023_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Prince Eric - Ursula's Groom",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-022_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tinker Bell - Generous Fairy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-022_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Sneezy - Very Allergic",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-022_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Stitch - New Dog",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-022_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Rolly - Hungry Pup",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-021_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Stitch - Carefree Surfer",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-021_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Prince Eric - Seafaring Prince",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-021_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sleepy - Nodding Off",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-021_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Queen of Hearts - Wonderland Empress",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-020_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pluto - Rescue Dog",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-020_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rapunzel - Sunshine",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-020_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Simba - Protective Cub",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-020_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Rapunzel - Gifted Artist",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-019_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Pongo - Determined Father",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-019_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mirabel Madrigal - Prophecy Finder",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-019_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sebastian - Court Composer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-019_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pluto - Friendly Pooch",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-018_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mirabel Madrigal - Gift of the Family",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-018_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rapunzel - Gifted with Healing",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-018_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Piglet - Very Small Animal",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-018_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Nana - Darling Family Pet",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-017_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Minnie Mouse - Musketeer Champion",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-017_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pluto - Determined Defender",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-017_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pumbaa - Friendly Warthog",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-017_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Prince Phillip - Dragonslayer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-016_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Piglet - Pooh Pirate Captain",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-016_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mulan - Reflecting",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-016_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mickey Mouse - Musketeer Captain",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-016_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Leader of the Band",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-015_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Perdita - Devoted Mother",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-015_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mulan - Free Spirit",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-015_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mr. Smee - Loyal First Mate",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-015_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Moana - Of Motunui",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-014_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mufasa - Betrayed Leader",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-014_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Max - Loyal Sheepdog",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-014_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Patch - Intimidating Pup",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-014_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Julieta Madrigal - Excellent Cook",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-013_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Friendly Face",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-013_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Orville - Ace Pilot",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-013_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Minnie Mouse - Beloved Princess",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-013_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Nani - Protective Sister",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-012_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mickey Mouse - True Friend",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-012_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "King Louie - Jungle VIP",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-012_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Goofy - Musketeer Swordsman",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-012_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maximus - Relentless Pursuer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-011_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Golden Harp - Enchanter of the Land",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-011_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mr. Snoops - Inept Businessman",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-011_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Happy - Good-Natured",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-011_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Gaston - Despicable Dealer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-010_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maximus - Palace Horse",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-010_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Miss Bianca - Rescue Aid Society Agent",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-010_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Grumpy - Bad-Tempered",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-010_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Félix Madrigal - Fun-Loving Family Man",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-009_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Minnie Mouse - Musical Artist",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-009_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Grand Duke - Advisor to the King",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-009_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lilo - Making a Wish",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-009_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Donald Duck - Musketeer Soldier",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-008_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Gaston - Baritone Bully",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-008_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lefou - Bumbler",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-008_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Lucky - The 15th Puppy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-008_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Kida - Protector of Atlantis",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-007_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Daisy Duck - Musketeer Spy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-007_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Eudora - Accomplished Seamstress",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-007_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "HeiHei - Boat Snack",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-007_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Daisy Duck - Lovely Lady",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-006_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Dopey - Always Playful",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-006_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hades - Lord of the Underworld",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-006_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Kida - Atlantean",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-006_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Doc - Leader of the Seven Dwarfs",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-005_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hades - King of Olympus",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-005_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cogsworth - Majordomo",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-005_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Joshua Sweet - The Doctor",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-005_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Goofy - Musketeer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-004_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cobra Bubbles - Just a Social Worker",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-004_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Cinderella - Melody Weaver",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-004_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Dalmatian Puppy - Tail Wagger",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-004_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Cinderella - Gentle and Kind",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-003_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Chernabog - Evildoer",
+       "mana_cost": "{10}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-003_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ariel - Singing Mermaid",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-003_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cinderella - Ballroom Sensation",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-003_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ariel - Spectacular Singer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-002_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Alma Madrigal - Family Matriarch",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-002_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Bernard - Brand-New Agent",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-002_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Christopher Robin - Adventurer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-002_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Bashful - Hopeless Romantic",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-001_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ariel - On Human Legs",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-001_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Baloo - von Bruinwald XIII",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["W"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-001_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Agustin Madrigal - Clumsy Dad",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["W"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-001_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Kuzco's Palace - Home of the Emperor",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-102_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ursula's Garden - Full of the Unfortunate",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-102_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ratigan's Marvelous Trap",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-102_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Stolen Scimitar",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-102_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ring The Bell",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-101_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dr. Facilier's Cards",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-101_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Fang - River City",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-101_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hidden Cove - Tranquil Haven",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-101_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Vision Slab",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-100_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pack Tactics",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-100_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "De Vil Manor - Cruella's Estate",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-100_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Vicious Betrayal",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-100_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Signed Contract",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-099_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Beast is Mine!",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-099_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Starlight Vial",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-099_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Improvise",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-099_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Robin's Bow",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-098_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hidden Inkcaster",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-098_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Hypnotize",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-098_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Sudden Chill",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-098_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Bounce",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-097_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "We Don't Talk About Bruno",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-097_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Steal from the Rich",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-097_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Airfoil",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-097_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ursula's Trickery",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-096_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Bibbidi Bobbidi Boo",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-096_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Strike a Good Match",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-096_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Stampede",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-096_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mother Knows Best",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-095_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Under The Sea",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-095_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "I Will Find My Way",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-095_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Virana - Fang Chief",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-095_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Has Set My Heaaaaaaart . . .",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-094_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tiana - True Princess",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-094_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Do It Again!",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-094_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Make the Potion",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-094_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Queen - Disguised Peddler",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-093_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dodge!",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-093_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Zazu - Steward of the Pride Lands",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-093_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tinker Bell - Most Helpful",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-093_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Wildcat - Mechanic",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-092_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tamatoa - Drab Little Crab",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-092_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Zeus - Mr. Lightning Bolts",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-092_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ray - Easygoing Firefly",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-092_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Ursula - Deceiver of All",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-091_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tor - Florist",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-091_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ratigan - Criminal Mastermind",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-091_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Peter Pan - Never Landing",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-091_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ursula - Deceiver",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-090_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mother Gothel - Selfish Manipulator",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-090_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Muses - Proclaimers of Heroes",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-090_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Queen of Hearts - Quick-Tempered",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-090_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Stitch - Covert Agent",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-089_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Prince John - Greediest of All",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-089_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "The Fates - Only One Eye",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-089_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Steamboat Pilot",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-089_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Starkey - Devious Pirate",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-088_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mickey Mouse - Artful Rogue",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-088_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Prince Phillip - Warden of the Woods",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-088_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pete - Bad Guy",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-088_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Prince Phillip - Vanquisher of Foes",
+       "mana_cost": "{9}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-087_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Skippy - Energetic Rabbit",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-087_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Panic - Underworld Imp",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-087_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Megara - Pulling the Strings",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-087_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pete - Rotten Guy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-086_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pain - Underworld Imp",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-086_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mad Hatter - Gracious Host",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-086_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Sir Hiss - Aggravating Asp",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-086_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pete - Born to Cheat",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-085_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Shenzi - Hyena Pack Leader",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-085_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Lucifer - Cunning Cat",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-085_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lady Tremaine - Wicked Stepmother",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-085_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Robin Hood - Daydreamer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-084_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Little John - Loyal Friend",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-084_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Kuzco - Temperamental Emperor",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-084_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pegasus - Gift for Hercules",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-084_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pegasus - Cloud Racer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-083_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Prince John - Phony King",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-083_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Jumba Jookiba - Renegade Scientist",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-083_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gaston - Scheming Suitor",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-083_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Panic - Immortal Sidekick",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-082_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Peter Pan - Lost Boy Leader",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-082_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Flynn Rider - His Own Biggest Fan",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-082_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "John Silver - Alien Pirate",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-082_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pain - Immortal Sidekick",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-081_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jasper - Common Crook",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-081_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Morph - Space Goo",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-081_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Flynn Rider - Confident Vagabond",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-081_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Megara - Liberated One",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-080_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Iago - Loud-Mouthed Parrot",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-080_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Milo Thatch - King of Atlantis",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-080_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Enchantress - Unexpected Judge",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-080_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dr. Facilier - Fortune Teller",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-079_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Megara - Captivating Cynic",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-079_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Milo Thatch - Clever Cartographer",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-079_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Horace - No-Good Scoundrel",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-079_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Lyle Tiberius Rourke - Cunning Mercenary",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-078_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Jasmine - Desert Warrior",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-078_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Hans - Scheming Prince",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-078_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Donald Duck - Sleepwalker",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-078_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Kit Cloudkicker - Tough Guy",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-077_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Donald Duck - Perfect Gentleman",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-077_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jaq - Connoisseur of Climbing",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-077_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Genie - The Ever Impressive",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-077_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Daisy Duck - Secret Agent",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-076_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hera - Queen of the Gods",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-076_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Genie - Powers Unleashed",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-076_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Jetsam - Riffraff",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-076_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Heihei - Bumbling Rooster",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-075_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cheshire Cat - From the Shadows",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-075_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Genie - On the Job",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-075_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Helga Sinclair - Vengeful Partner",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-075_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Cheshire Cat - Always Grinning",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-074_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Flynn Rider - Charming Rogue",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-074_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Helga Sinclair - Femme Fatale",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-074_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hades - Double Dealer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-074_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Friar Tuck - Priest of Nottingham",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-073_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Bucky - Squirrel Squeak Tutor",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-073_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Gus - Champion of Cheese",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-073_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Duke Of Weselton - Opportunistic Official",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-073_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cruella De Vil - Miserable As Usual",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-072_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Belle - Hidden Archer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-072_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Gunther - Interior Designer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-072_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Flotsam - Riffraff",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-072_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Belle - Bookworm",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-071_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Cheshire Cat - Not All There",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-071_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Diablo - Maleficent's Spy",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-071_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Don Karnage - Prince of Pirates",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-071_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Cursed Merfolk - Ursula's Handiwork",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-070_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Diablo - Devoted Herald",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-070_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Beast - Relentless",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-070_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Beast - Wolfsbane",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-070_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cri-Kee - Lucky Cricket",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["G"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-069_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cubby - Mighty Lost Boy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-069_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Arthur - Trained Swordsman",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-069_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Aladdin - Prince Ali",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["G"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-069_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Motunui - Island Paradise",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-170_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Sardine Can",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-170_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Scepter Of Arendelle",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-170_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Winter Camp - Medical Tent",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-170_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ariel's Grotto - A Secret Place",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-169_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "McDuck Manor - Scrooge's Mansion",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-169_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pawpsicle",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-169_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Magic Golden Flower",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-169_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Belle's House - Maurice's Workshop",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-168_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Maurice's Workshop",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-168_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Fishbone Quill",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-168_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Ice Block",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-168_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Great Stone Dragon",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-167_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Eye of the Fates",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-167_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Vault Door",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-167_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Gumbo Pot",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-167_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Scrooge's Top Hat",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-166_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Fang Crossbow",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-166_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Coconut Basket",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-166_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Field of Ice",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-166_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Treasures Untold",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-165_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Lucky Dime",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-165_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Nothing to Hide",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-165_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Work Together",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-165_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Launch",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-164_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "One Jump Ahead",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-164_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Heart of Te Fiti",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-164_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Seldom All They Seem",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-164_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Four Dozen Eggs",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-163_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Aurelian Gyrosensor",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-163_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Let It Go",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-163_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Glean",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-163_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Dig A Little Deeper",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-162_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Falling Down the Rabbit Hole",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-162_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "If It's Not Baroque",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-162_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Repair",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-162_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "How Far I'll Go",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-161_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Winnie The Pooh - Having a Think",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-161_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tuk Tuk - Curious Partner",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-161_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Develop Your Brain",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-161_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Triton - Young Prince",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-160_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Triton - The Sea King",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-160_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Friend Like Me",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-160_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Nokk - Water Spirit",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-160_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tamatoa - So Shiny!",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-159_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Triton - Discerning King",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-159_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sisu - Divine Water Dragon",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-159_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Distract",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-159_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Wendy Darling - Authority on Peter Pan",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-158_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Scar - Mastermind",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-158_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Triton - Champion of Atlantica",
+       "mana_cost": "{9}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-158_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Rabbit - Reluctant Host",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-158_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tinker Bell - Very Clever Fairy",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-157_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Robin Hood - Unrivaled Archer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-157_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Prince Charming - Heir to the Throne",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-157_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Transformed Chef - Castle Stove",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-157_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "The Queen - Mirror Seeker",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-156_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "The Queen - Diviner",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-156_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Owl - Logical Lecturer",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-156_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Philoctetes - Trainer of Heroes",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-156_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Sisu - Wise Friend",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-155_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Scrooge McDuck - Uncle Moneybags",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-155_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Noi - Orphaned Thief",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-155_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mufasa - King of the Pride Lands",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-155_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Scuttle - Expert on Humans",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-154_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Nick Wilde - Wily Fox",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-154_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Scrooge McDuck - Richest Duck in the World",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-154_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mickey Mouse - Detective",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-154_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Rapunzel - Appreciative Artist",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-153_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mrs. Judson - Housekeeper",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-153_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Rufus - Orphanage Cat",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-153_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Merlin - Self-Appointed Mentor",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-153_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Judy Hopps - Optimistic Officer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-152_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Prince Phillip - Gallant Defender",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-152_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maurice - World-Famous Inventor",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-152_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pluto - Mickey's Clever Friend",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-152_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mama Odie - Mystical Maven",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-151_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Maleficent - Uninvited",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-151_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Pascal - Inquisitive Pet",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-151_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jasmine - Heir of Agrabah",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-151_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Olaf - Trusting Companion",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-150_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maid Marian - Delightful Dreamer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-150_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "James - Role Model",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-150_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Maleficent - Sinister Visitor",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-150_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Olaf - Carrot Enthusiast",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-149_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Hiram Flaversham - Toymaker",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-149_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jasmine - Queen of Agrabah",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-149_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Louie - Chill Nephew",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-149_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Grand Pabbie - Oldest and Wisest",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-148_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "John Silver - Terror of the Realm",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-148_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Kit Cloudkicker - Spunky Bear Cub",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-148_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Jasmine - Disguised",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-148_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Iduna - Caring Mother",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-147_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Kit Cloudkicker - Navigator",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-147_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Gaston - Intellectual Powerhouse",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-147_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hades - Infernal Schemer",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-147_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gramma Tala - Storyteller",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-146_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Hans - Noble Scoundrel",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-146_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "King Louie - Bandleader",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-146_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Duke Weaselton - Small-Time Crook",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-146_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Hades - Meticulous Plotter",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-145_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cruella De Vil - Perfectly Wretched",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-145_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Huey - Savvy Nephew",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-145_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Flounder - Voice of Reason",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-145_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Flounder - Collector's Companion",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-144_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Gyro Gearloose - Gadget Whiz",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-144_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Cruella De Vil - Fashionable Cruiser",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-144_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Donald Duck - Strutting His Stuff",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-144_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Cogsworth - Talking Clock",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-143_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Chief Tui - Respected Leader",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-143_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gramma Tala - Spirit of the Ocean",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-143_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Fa Li - Mulan's Mother",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-143_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Cogsworth - Grandfather Clock",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-142_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dang Hu - Talon Chief",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-142_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Belle - Strange but Special",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-142_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Gramma Tala - Keeper of Ancient Stories",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-142_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Genie - Cramped in the Lamp",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-141_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Caterpillar - Calm and Collected",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-141_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Belle - Inventive Engineer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-141_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Aurora - Tranquil Princess",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-141_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Flintheart Glomgold - Lone Cheater",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-140_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Aurora - Regal Princess",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-140_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Aurora - Lore Guardian",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-140_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Basil - Perceptive Investigator",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-140_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dewey - Showy Nephew",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-139_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ariel - Treasure Collector",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-139_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Aurora - Dreaming Guardian",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-139_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Basil - Of Baker Street",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-139_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Anna - True-Hearted",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-138_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Basil - Great Mouse Detective",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-138_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Captain Amelia - First in Command",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-138_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Aurora - Briar Rose",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-138_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Audrey Ramirez - The Engineer",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-137_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ariel - Whoseit Collector",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["U"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-137_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Alice - Growing Girl",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["U"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-137_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Anna - Braving the Storm",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["U"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-137_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sword In The Stone",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-136_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "RLS Legacy - Solar Galleon",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-136_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Sword of Truth",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-136_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Training Grounds - Impossible Pillar",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-136_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Jolly Roger - Hook's Ship",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-135_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Shield of Virtue",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-135_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Snuggly Duckling - Disreputable Pub",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-135_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Peter Pan's Dagger",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-135_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Dinner Bell",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-134_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Poisoned Apple",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-134_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Vitalisphere",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-134_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Agrabah - Marketplace",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-134_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Sumerian Talisman",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-133_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "You Can Fly!",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-133_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "The Plank",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-133_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Tangle",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-133_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Medallion Weights",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-132_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maui's Fish Hook",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-132_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "What did you call me?",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-132_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "He's Got a Sword!",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-132_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "The Most Diabolical Scheme",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-131_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Fan The Flames",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-131_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Imperial Proclamation",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-131_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Voyage",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-131_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Dragon Fire",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-130_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "On Your Feet! Now!",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-130_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Teeth and Ambitions",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-130_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Brawl",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-130_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "I've Got a Dream",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-129_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Cut to the Chase",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-129_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Be King Undisputed",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-129_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Go the Distance",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-129_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "A Pirate's Life",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-128_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Divebomb",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 0,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-128_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tuk Tuk - Wrecking Ball",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-128_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Be Prepared",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-128_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Tigger - Wonderful Thing",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-127_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Tuk Tuk - Lively Partner",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-127_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Webby Vanderquack - Enthusiastic Duck",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-127_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Tigger - One of a Kind",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-127_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Trigger - Not-So-Sharp Shooter",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-126_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Te Ka - The Burning One",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-126_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Shere Khan - Menacing Predator",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-126_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Tong - Survivor",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-126_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Stitch - Abomination",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-125_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Sisu - Empowering Sibling",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-125_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Scar - Vicious Cheater",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-125_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Stitch - Little Rocket",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-125_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Slightly - Lost Boy",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-124_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Raya - Warrior of Kumandra",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-124_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Sisu - Emboldened Warrior",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-124_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Sergeant Tibbs - Courageous Cat",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-124_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Sisu - Daring Visitor",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-123_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Raya - Leader of Heart",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-123_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Simba - Scrappy Cub",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-123_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Scar - Shameless Firebrand",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-123_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Scroop - Backstabber",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-122_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Raya - Guardian of the Dragon Gem",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-122_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Raya - Headstrong",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-122_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Scar - Fiery Usurper",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-122_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Rapunzel - Letting Down Her Hair",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-121_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Raya - Fierce Protector",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-121_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Prince Eric - Expert Helmsman",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-121_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Ratigan - Very Large Mouse",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-121_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Queen of Hearts - Sensing Weakness",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-120_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Peter Pan - Pirate's Bane",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-120_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Pegasus - Flying Steed",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-120_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Pongo - Ol' Rascal",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-120_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Queen of Hearts - Impulsive Ruler",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-119_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Noi - Acrobatic Baby",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-119_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Peter Pan - Never Land Hero",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-119_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Peter Pan - Fearless Fighter",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-119_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Nessus - River Guardian",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-118_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Namaari - Nemesis",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-118_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mulan - Imperial Soldier",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-118_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Nutsy - Vulture Henchman",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-118_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Moana - Chosen by the Ocean",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-117_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Namaari - Heir of Fang",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-117_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Moana - Undeterred Voyager",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-117_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mulan - Soldier in Training",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-117_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Mother Gothel - Withered and Wicked",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-116_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Moana - Born Leader",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-116_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Mulan - Injured Soldier",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-116_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Minnie Mouse - Always Classy",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-116_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mulan - Enemy of Entanglement",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-115_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Mickey Mouse - Brave Little Tailor",
+       "mana_cost": "{8}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-115_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Milo Thatch - Spirited Scholar",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-115_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Minnie Mouse - Zipping Around",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-115_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Maui - Whale",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-114_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Minnie Mouse - Wide-Eyed Diver",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-114_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Maui - Hero to All",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-114_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Mulan - Elite Archer",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-114_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maui - Soaring Demigod",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-113_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Minnie Mouse - Stylish Surfer",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-113_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lumiere - Fiery Friend",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-113_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Maleficent - Monstrous Dragon",
+       "mana_cost": "{9}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-113_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Li Shang - Valorous General",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-112_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Madame Medusa - The Boss",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-112_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Lumiere - Hotheaded Candelabra",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-112_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Lefou - Instigator",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-112_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Li Shang - General's Son",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-111_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Kakamora - Menacing Sailor",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-111_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Lady Tremaine - Overbearing Matriarch",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-111_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Goofy - Daredevil",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-111_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Khan - Beloved Steed",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-110_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Lady Tremaine - Imperious Queen",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-110_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jim Hawkins - Thrill Seeker",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-110_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Gaston - Arrogant Hunter",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-110_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Hercules - Daring Demigod",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-109_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Honest John - Not That Honest",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-109_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Jim Hawkins - Space Traveler",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-109_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Elsa - Ice Surfer",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-109_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Donald Duck - Boisterous Fowl",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-108_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Hydra - Deadly Serpent",
+       "mana_cost": "{6}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 5,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-108_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Hercules - Clumsy Kid",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-108_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Fidget - Ratigan's Henchman",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-108_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "HeiHei - Accidental Explorer",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-107_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Goofy - Super Goof",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-107_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Captain Hook - Ruthless Pirate",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-107_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Felicia - Always Hungry",
+       "mana_cost": "{1}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-107_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Captain - Colonel's Lieutenant",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-106_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Flynn Rider - Frenemy",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-106_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Donald Duck - Not Again!",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-106_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Della Duck - Unstoppable Mom",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-106_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Card Soldiers - Full Deck",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-105_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Captain Hook - Master Swordsman",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "rare",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-105_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Fa Zhou - Mulan's Father",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-105_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Aladdin - Street Rat",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-105_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Aladdin - Heroic Outlaw",
+       "mana_cost": "{7}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 1,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-104_716x1000.jpeg"
+       },
+       "set": "1"
+    },
+     {
+       "name": "Benja - Bold Uniter",
+       "mana_cost": "{4}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-104_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Billy Bones - Keeper of the Map",
+       "mana_cost": "{5}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-104_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Boun - Precocious Entrepreneur",
+       "mana_cost": "{2}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-104_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Beast - Wounded",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "uncommon",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/004-103_716x1000.jpeg"
+       },
+       "set": "4"
+    },
+     {
+       "name": "Ariel - Adventurous Collector",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "mythic",
+       "colors": ["R"],
+       "rating": 4,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/003-103_716x1000.jpeg"
+       },
+       "set": "3"
+    },
+     {
+       "name": "Baloo - Fun-Loving Bear",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 3,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/002-103_716x1000.jpeg"
+       },
+       "set": "2"
+    },
+     {
+       "name": "Abu - Mischievous Monkey",
+       "mana_cost": "{3}",
+       "type": "Instant",
+       "rarity": "common",
+       "colors": ["R"],
+       "rating": 2,
+       "image_uris": {
+          "en": "https://images.dreamborn.ink/cards/en/tts/001-103_716x1000.jpeg"
+       },
+       "set": "1"
     }
 ]
 [Settings]


### PR DESCRIPTION
Add the following to the template file for our drafters!
* Missing cards from Set 1-3
* All Set 4 cards
* Colors (so draftmancer can color-balance packs better)
* Ratings allow draftmancer bots to evaluate Lorcana cards in a vacuum (courtesy of Fortyborn - https://twitter.com/Fortyborn and Frank Karsten - https://infinite.tcgplayer.com/article/The-Rise-Of-The-Floodborn-Booster-Draft-And-Sealed-Deck-Tier-List/2c4de6b2-1d25-4431-b5dc-e413f270d6fe/)
* Rarity - compresses legendary and super rare into mythic, but makes it easy enough to replicate lorcana boosters if you want
* Set - just the number